### PR TITLE
Log is not available outside of phpDocumentor, so check it exists

### DIFF
--- a/src/phpDocumentor/Reflection/FileReflector.php
+++ b/src/phpDocumentor/Reflection/FileReflector.php
@@ -226,7 +226,11 @@ class FileReflector extends ReflectionAbstract implements PHPParser_NodeVisitor
                         array_shift($comments);
                     }
                 } catch (\Exception $e) {
-                    $this->log($e->getMessage(), Log::CRIT);
+                    if (class_exists('phpDocumentor\Plugin\Core\Log')) {
+                        $this->log($e->getMessage(), Log::CRIT);
+                    } else {
+                        $this->log($e->getMessage(), 2);
+                    }
                 }
             }
 


### PR DESCRIPTION
The Log class from phpdocumentor/phpdocumentor might not be available. Fall back to a magic number if the class doesn't exist.

Related #3.
