### PR TITLE
Explode into a variable, so end() will not trigger a Strict standards notice

### DIFF
--- a/src/phpDocumentor/Reflection/FileReflector.php
+++ b/src/phpDocumentor/Reflection/FileReflector.php
@@ -341,7 +341,8 @@ class FileReflector extends ReflectionAbstract implements PHPParser_NodeVisitor
                         '\\',
                         trim($prettyPrinter->prettyPrintExpr($node->args[0]->value), '\'')
                     );
-                    $shortName = end(explode('\\', $name));
+                    $parts = explode('\\', $name);
+                    $shortName = end($parts);
 
                     $constant = new PHPParser_Node_Const($shortName, $node->args[1]->value, $node->getAttributes());
                     $constant->namespacedName = new PHPParser_Node_Name($name);


### PR DESCRIPTION
When running under PHP 5.4.15, I get the following notice a lot:

`Strict standards: Only variables should be passed by reference in /path/vendor/phpdocumentor/reflection/src/phpDocumentor/Reflection/FileReflector.php on line 344`
