### PR TITLE
Wrong parameters for mt_rand()

### DIFF
--- a/src/phpDocumentor/Reflection/PrettyPrinter.php
+++ b/src/phpDocumentor/Reflection/PrettyPrinter.php
@@ -58,7 +58,7 @@ class PrettyPrinter extends PHPParser_PrettyPrinter_Zend
      */
     public function __construct()
     {
-        $this->noIndentToken = mt_rand(true);
+        $this->noIndentToken = mt_rand();
     }
 
 


### PR DESCRIPTION
mt_rand() Should not take any parameters to get the full range.
