### PR TITLE
Add a backward compatibility with php-parser 0.9.2

### DIFF
--- a/src/phpDocumentor/Reflection/PrettyPrinter.php
+++ b/src/phpDocumentor/Reflection/PrettyPrinter.php
@@ -48,6 +48,10 @@ class PrettyPrinter extends PHPParser_PrettyPrinter_Zend
      */
     public function pScalar_String(PHPParser_Node_Scalar_String $node)
     {
+        if (method_exists($this, 'pSafe')) {
+            return $this->pSafe($node->getAttribute('originalValue'));
+        }
+        
         return $this->pNoIndent($node->getAttribute('originalValue'));
     }
 


### PR DESCRIPTION
In `nikic/php-parser` 0.9.2 they break compatibility with the 0.9.1 version.

pNoIndent methode was rename to pSafe
