### PR TITLE
Fixed dependency on nikic/php-parser to stay < 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=5.3.3",
         "psr/log": "~1.0",
-        "nikic/php-parser": ">=0.9",
+        "nikic/php-parser": "0.9.*",
         "phpdocumentor/reflection-docblock": "2.*@dev"
     },
     "suggests": {


### PR DESCRIPTION
1.0-dev has breaking changes so phpdoc will not work anymore when using that version.

Fixed composer dependency so that it will only install compatible versions.
