### PR TITLE
PrettyPrinter workaround removed

### DIFF
--- a/src/phpDocumentor/Reflection/PrettyPrinter.php
+++ b/src/phpDocumentor/Reflection/PrettyPrinter.php
@@ -55,14 +55,4 @@ class PrettyPrinter extends PHPParser_PrettyPrinter_Zend
         return $this->pNoIndent($node->getAttribute('originalValue'));
     }
 
-    /**
-     * Work around PHPParser_PrettyPrinterAbstract::__construct's call to
-     * uniqid() until https://github.com/nikic/PHP-Parser/pull/65 has been
-     * merged in.
-     */
-    public function __construct()
-    {
-        $this->noIndentToken = mt_rand();
-    }
-
 }


### PR DESCRIPTION
Patch has been merged in 0.9.4 (verified)
https://github.com/nikic/PHP-Parser/pull/65
https://github.com/phpDocumentor/Reflection/blob/master/composer.json#L15
