### PR TITLE
ProjectDescriptor is final it can be mocked so replace it with interface

### DIFF
--- a/src/phpDocumentor/Descriptor/ProjectAnalyzer.php
+++ b/src/phpDocumentor/Descriptor/ProjectAnalyzer.php
@@ -11,6 +11,8 @@
 
 namespace phpDocumentor\Descriptor;
 
+use phpDocumentor\Descriptor\Interfaces\ProjectInterface;
+
 /**
  * Analyzes a Project Descriptor and collects key information.
  *
@@ -38,11 +40,11 @@ class ProjectAnalyzer
     /**
      * Analyzes the given project descriptor and populates this object's properties.
      *
-     * @param ProjectDescriptor $projectDescriptor
+     * @param ProjectInterface $projectDescriptor
      *
      * @return void
      */
-    public function analyze(ProjectDescriptor $projectDescriptor)
+    public function analyze(ProjectInterface $projectDescriptor)
     {
         $this->unresolvedParentClassesCount = 0;
 
@@ -120,11 +122,11 @@ TEXT;
     /**
      * Returns all elements from the project descriptor.
      *
-     * @param ProjectDescriptor $projectDescriptor
+     * @param ProjectInterface $projectDescriptor
      *
      * @return DescriptorAbstract[]
      */
-    protected function findAllElements(ProjectDescriptor $projectDescriptor)
+    protected function findAllElements(ProjectInterface $projectDescriptor)
     {
         return $projectDescriptor->getIndexes()->get('elements', new Collection());
     }

--- a/tests/unit/phpDocumentor/Descriptor/AnalyzerTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/AnalyzerTest.php
@@ -69,7 +69,7 @@ class AnalyzerTest extends \PHPUnit_Framework_TestCase
         $projectDescriptor = $this->fixture->getProjectDescriptor();
 
         // assert functioning
-        $this->assertInstanceOf('phpDocumentor\Descriptor\ProjectDescriptor', $projectDescriptor);
+        $this->assertInstanceOf('phpDocumentor\Descriptor\Interfaces\ProjectInterface', $projectDescriptor);
         $this->assertCount(1, $projectDescriptor->getFiles());
     }
 
@@ -81,7 +81,7 @@ class AnalyzerTest extends \PHPUnit_Framework_TestCase
     {
         $this->fixture->createProjectDescriptor();
 
-        $this->assertInstanceOf('phpDocumentor\Descriptor\ProjectDescriptor', $this->fixture->getProjectDescriptor());
+        $this->assertInstanceOf('phpDocumentor\Descriptor\Interfaces\ProjectInterface', $this->fixture->getProjectDescriptor());
         $this->assertEquals(
             Analyzer::DEFAULT_PROJECT_NAME,
             $this->fixture->getProjectDescriptor()->getName()

--- a/tests/unit/phpDocumentor/Descriptor/ProjectAnalyzerTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/ProjectAnalyzerTest.php
@@ -3,6 +3,7 @@
 namespace phpDocumentor\Descriptor;
 
 use Mockery as m;
+use phpDocumentor\Descriptor\Interfaces\ProjectInterface;
 
 /**
  * Tests for the \phpDocumentor\Descriptor\ProjectAnalyzer class.
@@ -182,18 +183,18 @@ TEXT;
     /**
      * Returns a mocked ProjectDescriptor object.
      *
-     * @return m\Mock|ProjectDescriptor
+     * @return m\Mock|ProjectInterface
      */
     protected function givenAProjectMock()
     {
-        return m::mock('phpDocumentor\Descriptor\ProjectDescriptor')->shouldIgnoreMissing();
+        return m::mock('phpDocumentor\Descriptor\Interfaces\ProjectInterface')->shouldIgnoreMissing();
     }
 
     /**
-     * Ensures that the ProjectDescriptor contains and returns the provided files.
+     * Ensures that the ProjectInterface contains and returns the provided files.
      *
-     * @param m\Mock|ProjectDescriptor $projectDescriptor
-     * @param array                    $files
+     * @param m\Mock|ProjectInterface $projectDescriptor
+     * @param array                   $files
      *
      * @return void
      */
@@ -203,7 +204,7 @@ TEXT;
     }
 
     /**
-     * Ensures that the ProjectDescriptor has an index 'elements' with the provided elements.
+     * Ensures that the ProjectInterface has an index 'elements' with the provided elements.
      *
      * @param m\Mock|ProjectDescriptor $projectDescriptor
      * @param array                    $elements
@@ -219,7 +220,7 @@ TEXT;
     /**
      * Ensures that the ProjectDescriptor has a root namespace with the provided array as children of that namespace.
      *
-     * @param m\Mock|ProjectDescriptor $projectDescriptor
+     * @param m\Mock|ProjectInterface $projectDescriptor
      * @param array $rootNamespaceChildren
      *
      * @return void


### PR DESCRIPTION
ProjectDescriptor is final it can be mocked so replace it with ProjectInterface. This is causing a number of test failures in PhpDocumentor2.

Warning: this is a BC break!