### PR TITLE
make tests fail, but run

### DIFF
--- a/src/phpDocumentor/Descriptor/Builder/Reflector/MethodAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/MethodAssembler.php
@@ -135,7 +135,7 @@ class MethodAssembler extends AssemblerAbstract
         // convert ParamTag into ParamDescriptor
         $lastParamTag = $this->analyzer->analyze($lastParamTag);
 
-        if ($lastParamTag->isVariadic()
+        if (is_object($lastParamTag) && $lastParamTag->isVariadic()
             && !in_array($lastParamTag->getVariableName(), array_keys($methodDescriptor->getArguments()->getAll()))
         ) {
             $argument = new ArgumentDescriptor();


### PR DESCRIPTION
This is quite a nasty fix, but it enables all unittests are running. So new tests can be added. Most of this code will be remove so I don't want to spent more time on discovering what is going on.