### PR TITLE
Extract comments from first childnode

### DIFF
--- a/tests/component/ProjectCreationTest.php
+++ b/tests/component/ProjectCreationTest.php
@@ -61,6 +61,17 @@ class ProjectCreationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('box',$constant->getValue());
     }
 
+    public function testFileWithDocBlock()
+    {
+        $fileName = __DIR__ . '/project/Pizza.php';
+        $project = $this->fixture->create('MyProject', [
+            $fileName
+        ]);
+
+        $this->assertArrayHasKey($fileName, $project->getFiles());
+        $this->assertInstanceOf(Docblock::class, $project->getFiles()[$fileName]->getDocBlock());
+    }
+
     public function testWithNamespacedClass()
     {
         $fileName = __DIR__ . '/project/Luigi/Pizza.php';

--- a/tests/component/project/Pizza.php
+++ b/tests/component/project/Pizza.php
@@ -11,6 +11,9 @@
  */
 
 
+/**
+ * Pizza base class
+ */
 class Pizza
 {
     /**


### PR DESCRIPTION
It seems that php-parser can add one or more doc nodes to nodes.
Since it isn't ware of files which can have a docblock in our situation
we have to extract this from the first node.