### PR TITLE
[WIP] Setup middleware usage in strategies

### DIFF
--- a/src/phpDocumentor/Reflection/Php/Factory/Argument.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Argument.php
@@ -41,6 +41,7 @@ final class Argument extends AbstractFactory implements ProjectFactoryStrategy
      */
     public function __construct(PrettyPrinter $prettyPrinter)
     {
+        parent::__construct();
         $this->valueConverter = $prettyPrinter;
     }
 

--- a/src/phpDocumentor/Reflection/Php/Factory/Constant.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Constant.php
@@ -40,6 +40,7 @@ final class Constant extends AbstractFactory implements ProjectFactoryStrategy
      */
     public function __construct(PrettyPrinter $prettyPrinter)
     {
+        parent::__construct();
         $this->valueConverter = $prettyPrinter;
     }
 

--- a/src/phpDocumentor/Reflection/Php/Factory/CreateCommand.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/CreateCommand.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright 2010-2015 Mike van Riel<mike@phpdoc.org>
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Reflection\Php\Factory;
+
+
+use phpDocumentor\Reflection\Php\StrategyContainer;
+use phpDocumentor\Reflection\Types\Context;
+
+final class CreateCommand
+{
+    private $object;
+
+    /**
+     * @var StrategyContainer
+     */
+    private $strategies;
+
+    /**
+     * @var Context
+     */
+    private $context;
+
+    public function __construct($object, StrategyContainer $strategies, Context $context = null)
+    {
+        $this->object = $object;
+        $this->strategies = $strategies;
+        $this->context = $context;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getObject()
+    {
+        return $this->object;
+    }
+
+    /**
+     * @return StrategyContainer
+     */
+    public function getStrategies()
+    {
+        return $this->strategies;
+    }
+
+    /**
+     * @return Context
+     */
+    public function getContext()
+    {
+        return $this->context;
+    }
+}

--- a/src/phpDocumentor/Reflection/Php/Factory/File.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/File.php
@@ -18,7 +18,7 @@ use phpDocumentor\Reflection\File as FileSystemFile;
 use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Middleware\ChainFactory;
 use phpDocumentor\Reflection\Middleware\Middleware;
-use phpDocumentor\Reflection\Php\Factory\File\CreateCommand;
+use phpDocumentor\Reflection\Php\Factory\File\CreateCommand as FileCreateCommand;
 use phpDocumentor\Reflection\Php\File as FileElement;
 use phpDocumentor\Reflection\Php\NodesFactory;
 use phpDocumentor\Reflection\Php\ProjectFactoryStrategy;
@@ -46,6 +46,8 @@ final class File extends AbstractFactory implements ProjectFactoryStrategy
      */
     private $nodesFactory;
 
+    private $fileMiddleware;
+
     /**
      * Initializes the object.
      *
@@ -54,13 +56,14 @@ final class File extends AbstractFactory implements ProjectFactoryStrategy
      */
     public function __construct(NodesFactory $nodesFactory, $middleware = array())
     {
+        parent::__construct();
         $this->nodesFactory = $nodesFactory;
 
         $lastCallable = function ($command) {
             return $this->createFile($command);
         };
 
-        $this->middlewareChain = ChainFactory::createExecutionChain($middleware, $lastCallable);
+        $this->fileMiddleware = ChainFactory::createExecutionChain($middleware, $lastCallable);
     }
 
     /**
@@ -86,8 +89,8 @@ final class File extends AbstractFactory implements ProjectFactoryStrategy
      */
     protected function doCreate($object, StrategyContainer $strategies, Context $context = null)
     {
-        $command = new CreateCommand($object, $strategies);
-        $middlewareChain = $this->middlewareChain;
+        $command = new FileCreateCommand($object, $strategies);
+        $middlewareChain = $this->fileMiddleware;
 
         return $middlewareChain($command);
     }
@@ -96,7 +99,7 @@ final class File extends AbstractFactory implements ProjectFactoryStrategy
      * @param CreateCommand $command
      * @return FileElement
      */
-    private function createFile(CreateCommand $command)
+    private function createFile(FileCreateCommand $command)
     {
         $file = $command->getFile();
         $code = $file->getContents();

--- a/src/phpDocumentor/Reflection/Php/Factory/Middleware/Implements_.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Middleware/Implements_.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright 2010-2015 Mike van Riel<mike@phpdoc.org>
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Reflection\Php\Factory\Middleware;
+
+
+use phpDocumentor\Reflection\Fqsen;
+use phpDocumentor\Reflection\Middleware\Middleware;
+
+final class Implements_ implements Middleware
+{
+
+    /**
+     * Executes this middle ware class.
+     *
+     * @param $command
+     * @param callable $next
+     *
+     * @return object
+     */
+    public function execute($command, callable $next)
+    {
+        $element = $next($command);
+        $object = $command->getObject();
+
+        if (isset($object->implements)) {
+            foreach ($object->implements as $interfaceClassName) {
+                $element->addInterface(
+                    new Fqsen('\\' . $interfaceClassName->toString())
+                );
+            }
+        }
+
+        return $element;
+    }
+}

--- a/src/phpDocumentor/Reflection/Php/Factory/Middleware/Statements.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Middleware/Statements.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright 2010-2015 Mike van Riel<mike@phpdoc.org>
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Reflection\Php\Factory\Middleware;
+
+
+use phpDocumentor\Reflection\Fqsen;
+use phpDocumentor\Reflection\Middleware\Middleware;
+use phpDocumentor\Reflection\Php\Factory\ClassConstantIterator;
+use phpDocumentor\Reflection\Php\Factory\PropertyIterator;
+use phpDocumentor\Reflection\Php\StrategyContainer;
+use phpDocumentor\Reflection\Types\Context;
+use PhpParser\Node\Stmt\ClassConst;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\TraitUse;
+use PhpParser\Node\Stmt\Property as PropertyNode;
+
+final class Statements implements Middleware
+{
+    private $callbacks;
+
+    public function __construct()
+    {
+        $this->callbacks[TraitUse::class] = function($classElement, $stmt) {
+            foreach ($stmt->traits as $use) {
+                $classElement->addUsedTrait(new Fqsen('\\'. $use->toString()));
+            }
+        };
+
+        $this->callbacks[ClassConst::class] = function($classElement, $stmt, $strategies, $context) {
+            $constants = new ClassConstantIterator($stmt);
+            foreach ($constants as $const) {
+                $element = $this->createMember($const, $strategies, $context);
+                $classElement->addConstant($element);
+            }
+        };
+
+        $this->callbacks[ClassMethod::class] = function ($classElement, $stmt, $strategies, $context) {
+            $method = $this->createMember($stmt, $strategies, $context);
+            $classElement->addMethod($method);
+        };
+
+        $this->callbacks[PropertyNode::class] = function ($classElement, $stmt, $strategies, $context) {
+            $properties = new PropertyIterator($stmt);
+            foreach ($properties as $property) {
+                $element = $this->createMember($property, $strategies, $context);
+                $classElement->addProperty($element);
+            }
+        };
+    }
+
+
+    /**
+     * Executes this middle ware class.
+     *
+     * @param $command
+     * @param callable $next
+     *
+     * @return object
+     */
+    public function execute($command, callable $next)
+    {
+        $element = $next($command);
+        $object = $command->getObject();
+        $strategies = $command->getStrategies();
+        $context = $command->getContext();
+
+        if (isset($object->stmts)) {
+            foreach ($object->stmts as $stmt) {
+                if (isset($this->callbacks[get_class($stmt)])) {
+                    $callBack = $this->callbacks[get_class($stmt)];
+                    $callBack($element, $stmt, $strategies, $context);
+                }
+            }
+        }
+
+        return $element;
+    }
+
+    /**
+     * @param Node|PropertyIterator|ClassConstantIterator|Doc $stmt
+     * @param StrategyContainer $strategies
+     * @param Context $context
+     * @return Element
+     */
+    protected function createMember($stmt, StrategyContainer $strategies, Context $context = null)
+    {
+        $strategy = $strategies->findMatching($stmt);
+        return $strategy->create($stmt, $strategies, $context);
+    }
+}

--- a/src/phpDocumentor/Reflection/Php/Factory/Property.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Property.php
@@ -42,6 +42,7 @@ final class Property extends AbstractFactory implements ProjectFactoryStrategy
      */
     public function __construct(PrettyPrinter $prettyPrinter)
     {
+        parent::__construct();
         $this->valueConverter = $prettyPrinter;
     }
 


### PR DESCRIPTION
In favor of #90 I implemented a POC using middlewares in the factory strategies. All complex logic is extracted from the strategy and moved to a middleware class. This allows us to reuse the middlewares in other strategies. It reduces the complexity of the strategies and makes it easier to write custom strategies.
