### PR TITLE
createDocBlock() must be an instance of PhpParser\Comment\Doc

### DIFF
--- a/example.php
+++ b/example.php
@@ -22,7 +22,7 @@ include 'vendor/autoload.php';
 $projectFactory = \phpDocumentor\Reflection\Php\ProjectFactory::createInstance();
 
 // Create an array of files to analize.
-$files = ['tests/example.file.php'];
+$files = [ new \phpDocumentor\Reflection\File\LocalFile('tests/example.file.php') ];
 
 //create a new project 'MyProject' containing all elements in the files.
 /** @var Project $project */

--- a/src/phpDocumentor/Reflection/Php/Factory/File.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/File.php
@@ -172,17 +172,37 @@ final class File extends AbstractFactory implements ProjectFactoryStrategy
         Context $context = null,
         $nodes = array()
     ) {
-        /** @var NodeAbstract $node */
         $node = current($nodes);
-        if ($node instanceof Node) {
-            $comments = $node->getAttribute('comments');
-            if (is_array($comments)) {
-                if ($node instanceof NamespaceNode) {
-                    $docBlock = $this->createDocBlock($strategies, current($comments), $context);
-                } elseif (count($comments) == 2) {
-                    $docBlock = $this->createDocBlock($strategies, current($comments), $context);
-                }
+        if (!$node instanceof Node) {
+            return $docBlock;
+        }
+
+        $comments = $node->getAttribute('comments');
+        if (!is_array($comments) || empty($comments)) {
+            return $docBlock;
+        }
+
+        $found = 0;
+        $firstDocBlock = null;
+        foreach ($comments as $comment) {
+            if (!$comment instanceof Doc) {
+                continue;
             }
+
+            if ($node instanceof NamespaceNode) {
+                return $this->createDocBlock($strategies, $comment, $context);
+            }
+
+            $found++;
+            if ($firstDocBlock === null) {
+                $firstDocBlock = $comment;
+            } elseif ($found > 2) {
+                break;
+            }
+        }
+
+        if ($found === 2) {
+            return $this->createDocBlock($strategies, $firstDocBlock, $context);
         }
 
         return $docBlock;

--- a/src/phpDocumentor/Reflection/Php/ProjectFactory.php
+++ b/src/phpDocumentor/Reflection/Php/ProjectFactory.php
@@ -66,7 +66,7 @@ final class ProjectFactory implements ProjectFactoryInterface
      * Creates a project from the set of files.
      *
      * @param string $name
-     * @param string[] $files
+     * @param \phpDocumentor\Reflection\File[] $files
      * @return Project
      * @throws Exception when no matching strategy was found.
      */


### PR DESCRIPTION
This PR fixes a bug where a node 'comments' attribute may contain Comment instances and not just Doc instances.

It also fixes the example.php so that it works again.