### PR TITLE
Typo in statement node class name fix

### DIFF
--- a/src/phpDocumentor/Reflection/FileReflector.php
+++ b/src/phpDocumentor/Reflection/FileReflector.php
@@ -484,7 +484,7 @@ class FileReflector extends ReflectionAbstract implements NodeVisitor
         $prettyPrinter = new PrettyPrinter;
 
         switch (get_class($node)) {
-            case 'PhpParser\Node\Stmt_Use':
+            case 'PhpParser\Node\Stmt\Use_':
                 /** @var \PhpParser\Node\Stmt\UseUse $use */
                 foreach ($node->uses as $use) {
                     $this->context->setNamespaceAlias(


### PR DESCRIPTION
No use statements are parsed due to this typo.