### PR TITLE
WIP: Adds support for return types on methods

### DIFF
--- a/src/phpDocumentor/Reflection/Php/Factory/Function_.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Function_.php
@@ -19,6 +19,7 @@ use phpDocumentor\Reflection\Php\Factory;
 use phpDocumentor\Reflection\Php\Function_ as FunctionDescriptor;
 use phpDocumentor\Reflection\Php\ProjectFactoryStrategy;
 use phpDocumentor\Reflection\Php\StrategyContainer;
+use phpDocumentor\Reflection\TypeResolver;
 use phpDocumentor\Reflection\Types\Context;
 use PhpParser\Comment\Doc;
 use PhpParser\Node\Stmt\Function_ as FunctionNode;
@@ -57,7 +58,13 @@ final class Function_ extends AbstractFactory implements ProjectFactoryStrategy
     {
         $docBlock = $this->createDocBlock($strategies, $object->getDocComment(), $context);
 
-        $function = new FunctionDescriptor($object->fqsen, $docBlock, new Location($object->getLine()));
+        $returnType = null;
+        if ($object->returnType !== null) {
+            $typeResolver = new TypeResolver();
+            $returnType = $typeResolver->resolve($object->returnType, $context);
+        }
+
+        $function = new FunctionDescriptor($object->fqsen, $docBlock, new Location($object->getLine()), $returnType);
 
         foreach ($object->params as $param) {
             $strategy = $strategies->findMatching($param);

--- a/src/phpDocumentor/Reflection/Php/Factory/Method.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Method.php
@@ -12,14 +12,14 @@
 
 namespace phpDocumentor\Reflection\Php\Factory;
 
-use InvalidArgumentException;
 use phpDocumentor\Reflection\Location;
 use phpDocumentor\Reflection\Php\Method as MethodDescriptor;
 use phpDocumentor\Reflection\Php\ProjectFactoryStrategy;
 use phpDocumentor\Reflection\Php\StrategyContainer;
 use phpDocumentor\Reflection\Php\Visibility;
+use phpDocumentor\Reflection\TypeResolver;
 use phpDocumentor\Reflection\Types\Context;
-use PhpParser\Comment\Doc;
+use phpDocumentor\Reflection\Types\Mixed_;
 use PhpParser\Node\Stmt\ClassMethod;
 
 /**
@@ -50,6 +50,12 @@ final class Method extends AbstractFactory implements ProjectFactoryStrategy
     {
         $docBlock = $this->createDocBlock($strategies, $object->getDocComment(), $context);
 
+        $returnType = null;
+        if ($object->returnType !== null) {
+            $typeResolver = new TypeResolver();
+            $returnType = $typeResolver->resolve($object->returnType, $context);
+        }
+
         $method = new MethodDescriptor(
             $object->fqsen,
             $this->buildVisibility($object),
@@ -57,7 +63,8 @@ final class Method extends AbstractFactory implements ProjectFactoryStrategy
             $object->isAbstract(),
             $object->isStatic(),
             $object->isFinal(),
-            new Location($object->getLine())
+            new Location($object->getLine()),
+            $returnType
         );
 
         foreach ($object->params as $param) {

--- a/src/phpDocumentor/Reflection/Php/Function_.php
+++ b/src/phpDocumentor/Reflection/Php/Function_.php
@@ -16,6 +16,8 @@ use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\Element;
 use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Location;
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Types\Mixed_;
 
 /**
  * Descriptor representing a function
@@ -43,20 +45,36 @@ final class Function_ implements Element
     private $location;
 
     /**
+     * @var Type
+     */
+    private $returnType;
+
+    /**
      * Initializes the object.
      *
      * @param Fqsen $fqsen
      * @param DocBlock|null $docBlock
+     * @param Location|null $location
+     * @param Type|null $returnType
      */
-    public function __construct(Fqsen $fqsen, DocBlock $docBlock = null, Location $location = null)
-    {
+    public function __construct(
+        Fqsen $fqsen,
+        DocBlock $docBlock = null,
+        Location $location = null,
+        Type $returnType = null
+    ) {
         if ($location === null) {
             $location = new Location(-1);
+        }
+
+        if ($returnType ===  null) {
+            $returnType = new Mixed_();
         }
 
         $this->fqsen = $fqsen;
         $this->docBlock = $docBlock;
         $this->location = $location;
+        $this->returnType = $returnType;
     }
 
     /**
@@ -115,5 +133,13 @@ final class Function_ implements Element
     public function getLocation()
     {
         return $this->location;
+    }
+
+    /**
+     * @return Type
+     */
+    public function getReturnType() : Type
+    {
+        return $this->returnType;
     }
 }

--- a/src/phpDocumentor/Reflection/Php/Method.php
+++ b/src/phpDocumentor/Reflection/Php/Method.php
@@ -17,6 +17,8 @@ use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Element;
 use phpDocumentor\Reflection\Location;
 use phpDocumentor\Reflection\Php\Visibility;
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Types\Mixed_;
 
 /**
  * Descriptor representing a Method in a Class, Interface or Trait.
@@ -52,6 +54,10 @@ final class Method implements Element
      * @var Location
      */
     private $location;
+    /**
+     * @var Type
+     */
+    private $returnType;
 
     /**
      * Initializes the all properties.
@@ -63,6 +69,7 @@ final class Method implements Element
      * @param bool $static
      * @param bool $final
      * @param Location|null $location
+     * @param Type $returnType
      */
     public function __construct(
         Fqsen $fqsen,
@@ -71,7 +78,8 @@ final class Method implements Element
         $abstract = false,
         $static = false,
         $final = false,
-        Location $location = null
+        Location $location = null,
+        Type $returnType = null
     ) {
         $this->fqsen = $fqsen;
         $this->visibility = $visibility;
@@ -85,10 +93,15 @@ final class Method implements Element
             $location = new Location(-1);
         }
 
+        if ($returnType ===  null) {
+            $returnType = new Mixed_();
+        }
+
         $this->abstract = $abstract;
         $this->static = $static;
         $this->final = $final;
         $this->location = $location;
+        $this->returnType = $returnType;
     }
 
     /**
@@ -189,5 +202,19 @@ final class Method implements Element
     public function getLocation()
     {
         return $this->location;
+    }
+
+    /**
+     * Returns the in code defined return type.
+     *
+     * Return types are introduced in php 7.0 when your could doesn't have a
+     * return type defined this method will return Mixed_ by default. The return value of this
+     * method is not affected by the return tag in your docblock.
+     *
+     * @return Type
+     */
+    public function getReturnType()
+    {
+        return $this->returnType;
     }
 }

--- a/tests/component/ProjectCreationTest.php
+++ b/tests/component/ProjectCreationTest.php
@@ -15,8 +15,10 @@ namespace phpDocumentor\Reflection;
 use Mockery as m;
 use phpDocumentor\Reflection\DocBlock\Tags\Param;
 use phpDocumentor\Reflection\File\LocalFile;
+use phpDocumentor\Reflection\Php\Interface_;
 use phpDocumentor\Reflection\Php\ProjectFactory;
 use phpDocumentor\Reflection\Types\Object_;
+use phpDocumentor\Reflection\Types\String_;
 
 /**
  * Intergration tests to check the correct working of processing a file into a project.
@@ -172,5 +174,18 @@ class ProjectCreationTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(['\\Packing' => new Fqsen('\\Packing')], $interface->getParents());
 
+    }
+
+    public function testMethodReturnType()
+    {
+        $fileName = __DIR__ . '/project/Packing.php';
+        $project = $this->fixture->create('MyProject', [
+            new LocalFile($fileName)
+        ]);
+
+        $this->assertArrayHasKey('\\Packing', $project->getFiles()[$fileName]->getInterfaces());
+        $interface = current($project->getFiles()[$fileName]->getInterfaces());
+
+        $this->assertEquals(new String_(),  $interface->getMethods()['\Packing::getName()']->getReturnType());
     }
 }

--- a/tests/component/project/Packing.php
+++ b/tests/component/project/Packing.php
@@ -12,5 +12,5 @@
 
 interface Packing
 {
-    public function getName();
+    public function getName() : string;
 }

--- a/tests/unit/phpDocumentor/Reflection/Php/Function_Test.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Function_Test.php
@@ -15,6 +15,8 @@ namespace phpDocumentor\Reflection\Php;
 use \Mockery as m;
 use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\Fqsen;
+use phpDocumentor\Reflection\Types\Mixed_;
+use phpDocumentor\Reflection\Types\String_;
 
 /**
  * Tests the functionality for the Function_ class.
@@ -80,5 +82,32 @@ class Function_Test extends \PHPUnit_Framework_TestCase
     public function testGetDocblock()
     {
         $this->assertSame($this->docBlock, $this->fixture->getDocBlock());
+    }
+
+    /**
+     * @covers ::getReturnType
+     * @covers ::__construct
+     */
+    public function testGetDefaultReturnType()
+    {
+        $method = new Function_($this->fqsen);
+        $this->assertEquals(new Mixed_(), $method->getReturnType());
+    }
+
+    /**
+     * @covers ::getReturnType
+     * @covers ::__construct
+     */
+    public function testGetReturnTypeFromConstructor()
+    {
+        $returnType = new String_();
+        $method = new Function_(
+            $this->fqsen,
+            null,
+            null,
+            $returnType
+        );
+
+        $this->assertSame($returnType, $method->getReturnType());
     }
 }

--- a/tests/unit/phpDocumentor/Reflection/Php/MethodTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/MethodTest.php
@@ -15,6 +15,8 @@ namespace phpDocumentor\Reflection\Php;
 use \Mockery as m;
 use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\Fqsen;
+use phpDocumentor\Reflection\Types\Mixed_;
+use phpDocumentor\Reflection\Types\String_;
 
 /**
  * Tests the functionality for the Method class.
@@ -134,5 +136,36 @@ class MethodTest extends \PHPUnit_Framework_TestCase
     {
         $method = new Method($this->fqsen);
         $this->assertEquals(new Visibility('public'), $method->getVisibility());
+    }
+
+    /**
+     * @covers ::getReturnType
+     * @covers ::__construct
+     */
+    public function testGetDefaultReturnType()
+    {
+        $method = new Method($this->fqsen);
+        $this->assertEquals(new Mixed_(), $method->getReturnType());
+    }
+
+    /**
+     * @covers ::getReturnType
+     * @covers ::__construct
+     */
+    public function testGetReturnTypeFromConstructor()
+    {
+        $returnType = new String_();
+        $method = new Method(
+            $this->fqsen,
+            new Visibility('public'),
+            null,
+            false,
+            false,
+            false,
+            null,
+            $returnType
+        );
+
+        $this->assertSame($returnType, $method->getReturnType());
     }
 }


### PR DESCRIPTION
In php7 return types are added to the syntax of php. This
change adds the detection of return types to the method factory.