### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "mockery/mockery":    "~0.8",
         "mikey179/vfsStream": "~1.2",
         "squizlabs/php_codesniffer": "^2.5",
-        "phpunit/phpunit": "^5.0"
+        "phpunit/phpunit": "^5.7"
     },
     "extra": {
         "branch-alias": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "f2ae8142b3d65d23c3984303208743f4",
+    "content-hash": "ced0a3d3d928a8ec06e853eae97b85d9",
     "packages": [
         {
             "name": "nikic/php-parser",
@@ -109,7 +109,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2017-04-30 11:58:12"
+            "time": "2017-04-30T11:58:12+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",

--- a/tests/component/ProjectCreationTest.php
+++ b/tests/component/ProjectCreationTest.php
@@ -19,13 +19,14 @@ use phpDocumentor\Reflection\Php\Interface_;
 use phpDocumentor\Reflection\Php\ProjectFactory;
 use phpDocumentor\Reflection\Types\Object_;
 use phpDocumentor\Reflection\Types\String_;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Intergration tests to check the correct working of processing a file into a project.
  *
  * @coversNothing
  */
-class ProjectCreationTest extends \PHPUnit_Framework_TestCase
+class ProjectCreationTest extends TestCase
 {
     /**
      * @var ProjectFactory

--- a/tests/component/ProjectNamespaceTest.php
+++ b/tests/component/ProjectNamespaceTest.php
@@ -26,13 +26,14 @@ use phpDocumentor\Reflection\Php\Factory\Method;
 use phpDocumentor\Reflection\Php\Factory\Property;
 use phpDocumentor\Reflection\Php\Factory\Trait_;
 use phpDocumentor\Reflection\Php\ProjectFactory;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Intergration tests to check the correct working of processing a namespace into a project.
  *
  * @coversNothing
  */
-class ProjectNamespaceTest extends \PHPUnit_Framework_TestCase
+class ProjectNamespaceTest extends TestCase
 {
     /**
      * @var ProjectFactory

--- a/tests/unit/phpDocumentor/Reflection/File/LocalFileTest.php
+++ b/tests/unit/phpDocumentor/Reflection/File/LocalFileTest.php
@@ -11,12 +11,13 @@
  */
 
 namespace phpDocumentor\Reflection\File;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass phpDocumentor\Reflection\File\LocalFile
  * @covers ::__construct
  */
-class LocalFileTest extends \PHPUnit_Framework_TestCase
+class LocalFileTest extends TestCase
 {
     /**
      * @covers ::getContents

--- a/tests/unit/phpDocumentor/Reflection/NodeVisitor/ElementNameResolverTest.php
+++ b/tests/unit/phpDocumentor/Reflection/NodeVisitor/ElementNameResolverTest.php
@@ -22,13 +22,14 @@ use PhpParser\Node\Stmt\ClassConst;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\NodeTraverser;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Testcase for FqsenResolver
  * @coversDefaultClass phpDocumentor\Reflection\NodeVisitor\ElementNameResolver
  * @covers ::<private>
  */
-class ElementNameResolverTest extends \PHPUnit_Framework_TestCase
+class ElementNameResolverTest extends TestCase
 {
     /**
      * @var ElementNameResolver

--- a/tests/unit/phpDocumentor/Reflection/Php/ArgumentTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/ArgumentTest.php
@@ -12,11 +12,13 @@
 
 namespace phpDocumentor\Reflection\Php;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests the functionality for the Argument class.
  * @coversDefaultClass phpDocumentor\Reflection\Php\Argument
  */
-class ArgumentTest extends \PHPUnit_Framework_TestCase
+class ArgumentTest extends TestCase
 {
 
     /**

--- a/tests/unit/phpDocumentor/Reflection/Php/Class_Test.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Class_Test.php
@@ -16,13 +16,14 @@ use Mockery as m;
 use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Location;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the functionality for the Class_ class.
  * @coversDefaultClass phpDocumentor\Reflection\Php\Class_
  */
 // @codingStandardsIgnoreStart
-class Class_Test extends \PHPUnit_Framework_TestCase
+class Class_Test extends TestCase
 // @codingStandardsIgnoreEnd
 {
     /**

--- a/tests/unit/phpDocumentor/Reflection/Php/ConstantTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/ConstantTest.php
@@ -14,12 +14,13 @@ namespace phpDocumentor\Reflection\Php;
 
 use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\Fqsen;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the functionality for the Constant class.
  * @coversDefaultClass phpDocumentor\Reflection\Php\Constant
  */
-class ConstantTest extends \PHPUnit_Framework_TestCase
+class ConstantTest extends TestCase
 {
     /** @var Constant $fixture */
     protected $fixture;

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/ClassConstantIteratorTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/ClassConstantIteratorTest.php
@@ -20,12 +20,13 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\ClassConst;
 use PhpParser\Node\Stmt\Property as PropertyNode;
 use PhpParser\Node\Stmt\PropertyProperty;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class PropertyIteratorTest
  * @coversDefaultClass \phpDocumentor\Reflection\Php\Factory\ClassConstantIterator
  */
-class ClassConstantIteratorTest extends \PHPUnit_Framework_TestCase
+class ClassConstantIteratorTest extends TestCase
 {
     /**
      * @covers ::current()

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/File/CreateCommandTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/File/CreateCommandTest.php
@@ -14,6 +14,7 @@ namespace phpDocumentor\Reflection\Php\Factory\File;
 
 use phpDocumentor\Reflection\File\LocalFile;
 use phpDocumentor\Reflection\Php\ProjectFactoryStrategies;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass phpDocumentor\Reflection\Php\Factory\File\CreateCommand
@@ -21,7 +22,7 @@ use phpDocumentor\Reflection\Php\ProjectFactoryStrategies;
  * @uses phpDocumentor\Reflection\File\LocalFile
  * @uses phpDocumentor\Reflection\Php\ProjectFactoryStrategies
  */
-class CreateCommandTest extends \PHPUnit_Framework_TestCase
+class CreateCommandTest extends TestCase
 {
     /**
      * @var CreateCommand

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/PropertyIteratorTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/PropertyIteratorTest.php
@@ -16,12 +16,13 @@ namespace phpDocumentor\Reflection\Php\Factory;
 use Mockery as m;
 use PhpParser\Node\Stmt\Property as PropertyNode;
 use PhpParser\Node\Stmt\PropertyProperty;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class PropertyIteratorTest
  * @coversDefaultClass \phpDocumentor\Reflection\Php\Factory\PropertyIterator
  */
-class PropertyIteratorTest extends \PHPUnit_Framework_TestCase
+class PropertyIteratorTest extends TestCase
 {
     /**
      * @covers ::current()

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/TestCase.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/TestCase.php
@@ -16,11 +16,12 @@ use Mockery as m;
 use phpDocumentor\Reflection\Php\ProjectFactoryStrategy;
 use phpDocumentor\Reflection\Php\StrategyContainer;
 use phpDocumentor\Reflection\Types\Context;
+use PHPUnit\Framework\TestCase as BaseTestCase;
 
 /**
  * Base test case for all strategies, to be sure that they check if the can handle objects before handeling them.
  */
-abstract class TestCase extends \PHPUnit_Framework_TestCase
+abstract class TestCase extends BaseTestCase
 {
     /**
      * @var ProjectFactoryStrategy

--- a/tests/unit/phpDocumentor/Reflection/Php/FileTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/FileTest.php
@@ -15,13 +15,14 @@ namespace phpDocumentor\Reflection\Php;
 use \Mockery as m;
 use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\Fqsen;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the functionality for the File class.
  *
  * @coversDefaultClass phpDocumentor\Reflection\Php\File
  */
-class FileTest extends \PHPUnit_Framework_TestCase
+class FileTest extends TestCase
 {
     const EXAMPLE_HASH   = 'a-hash-string';
     const EXAMPLE_PATH   = 'a-path-string';

--- a/tests/unit/phpDocumentor/Reflection/Php/Function_Test.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Function_Test.php
@@ -17,13 +17,14 @@ use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Types\Mixed_;
 use phpDocumentor\Reflection\Types\String_;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the functionality for the Function_ class.
  * @coversDefaultClass phpDocumentor\Reflection\Php\Function_
  */
 // @codingStandardsIgnoreStart
-class Function_Test extends \PHPUnit_Framework_TestCase
+class Function_Test extends TestCase
 // @codingStandardsIgnoreEnd
 {
     /** @var Function_ $fixture */

--- a/tests/unit/phpDocumentor/Reflection/Php/Interface_Test.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Interface_Test.php
@@ -15,13 +15,14 @@ namespace phpDocumentor\Reflection\Php;
 use Mockery as m;
 use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\Fqsen;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the functionality for the Interface_ class.
  * @coversDefaultClass phpDocumentor\Reflection\Php\Interface_
  */
 // @codingStandardsIgnoreStart
-class Interface_Test extends \PHPUnit_Framework_TestCase
+class Interface_Test extends TestCase
 // @codingStandardsIgnoreEnd
 {
     /** @var Interface_ $fixture */

--- a/tests/unit/phpDocumentor/Reflection/Php/MethodTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/MethodTest.php
@@ -17,12 +17,13 @@ use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Types\Mixed_;
 use phpDocumentor\Reflection\Types\String_;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the functionality for the Method class.
  * @coversDefaultClass phpDocumentor\Reflection\Php\Method
  */
-class MethodTest extends \PHPUnit_Framework_TestCase
+class MethodTest extends TestCase
 {
     /** @var Method $fixture */
     protected $fixture;

--- a/tests/unit/phpDocumentor/Reflection/Php/Namespace_Test.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Namespace_Test.php
@@ -14,6 +14,7 @@ namespace phpDocumentor\Reflection\Php;
 
 use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\DocBlock;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the functionality for the Namespace_ class.
@@ -21,7 +22,7 @@ use phpDocumentor\Reflection\DocBlock;
  * @coversDefaultClass phpDocumentor\Reflection\Php\Namespace_
  */
 // @codingStandardsIgnoreStart
-class Namespace_Test extends \PHPUnit_Framework_TestCase
+class Namespace_Test extends TestCase
 // @codingStandardsIgnoreEnd
 {
     /** @var Namespace_ $fixture */

--- a/tests/unit/phpDocumentor/Reflection/Php/ProjectFactoryStrategiesTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/ProjectFactoryStrategiesTest.php
@@ -13,13 +13,14 @@
 namespace phpDocumentor\Reflection\Php;
 
 use phpDocumentor\Reflection\Php\Factory\DummyFactoryStrategy;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test case for ProjectFactoryStrategies
  *
  * @coversDefaultClass phpDocumentor\Reflection\Php\ProjectFactoryStrategies
  */
-class ProjectFactoryStrategiesTest extends \PHPUnit_Framework_TestCase
+class ProjectFactoryStrategiesTest extends TestCase
 {
     /**
      * @covers ::__construct

--- a/tests/unit/phpDocumentor/Reflection/Php/ProjectFactoryTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/ProjectFactoryTest.php
@@ -15,6 +15,7 @@ namespace phpDocumentor\Reflection\Php;
 use Mockery as m;
 use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Php\Factory\DummyFactoryStrategy;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test case for ProjectFactory
@@ -23,7 +24,7 @@ use phpDocumentor\Reflection\Php\Factory\DummyFactoryStrategy;
  * @covers ::create
  * @covers ::<private>
  */
-class ProjectFactoryTest extends \PHPUnit_Framework_TestCase
+class ProjectFactoryTest extends TestCase
 {
     /**
      * @covers ::__construct

--- a/tests/unit/phpDocumentor/Reflection/Php/ProjectTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/ProjectTest.php
@@ -13,13 +13,14 @@
 namespace phpDocumentor\Reflection\Php;
 
 use phpDocumentor\Reflection\Fqsen;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the functionality for the Project class.
  *
  * @coversDefaultClass phpDocumentor\Reflection\Php\Project
  */
-class ProjectTest extends \PHPUnit_Framework_TestCase
+class ProjectTest extends TestCase
 {
     const EXAMPLE_NAME = 'Initial name';
 

--- a/tests/unit/phpDocumentor/Reflection/Php/PropertyTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/PropertyTest.php
@@ -15,13 +15,14 @@ namespace phpDocumentor\Reflection\Php;
 use \Mockery as m;
 use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\Fqsen;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the functionality for the Property class.
  *
  * @coversDefaultClass phpDocumentor\Reflection\Php\Property
  */
-class PropertyTest extends \PHPUnit_Framework_TestCase
+class PropertyTest extends TestCase
 {
     /**
      * @var Fqsen

--- a/tests/unit/phpDocumentor/Reflection/Php/Trait_Test.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Trait_Test.php
@@ -15,13 +15,14 @@ namespace phpDocumentor\Reflection\Php;
 use \Mockery as m;
 use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\Fqsen;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the functionality for the Trait_ class.
  * @coversDefaultClass phpDocumentor\Reflection\Php\Trait_
  */
 // @codingStandardsIgnoreStart
-class Trait_Test extends \PHPUnit_Framework_TestCase
+class Trait_Test extends TestCase
 // @codingStandardsIgnoreEnd
 {
     /** @var Trait_ $fixture */

--- a/tests/unit/phpDocumentor/Reflection/Php/VisibilityTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/VisibilityTest.php
@@ -12,11 +12,13 @@
 
 namespace phpDocumentor\Reflection\Php;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test case for Visibility
  * @coversDefaultClass phpDocumentor\Reflection\Php\Visibility
  */
-class VisibilityTest extends \PHPUnit_Framework_TestCase
+class VisibilityTest extends TestCase
 {
     /**
      * @param $input

--- a/tests/unit/phpDocumentor/Reflection/PrettyPrinterTest.php
+++ b/tests/unit/phpDocumentor/Reflection/PrettyPrinterTest.php
@@ -13,7 +13,7 @@
 namespace phpDocumentor\Reflection;
 
 use PhpParser\Node\Scalar\String_;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class for testing the PrettyPrinter.
@@ -23,7 +23,7 @@ use PHPUnit_Framework_TestCase;
  * @license   http://www.opensource.org/licenses/mit-license.php MIT
  * @link      http://phpdoc.org
  */
-class PrettyPrinterTest extends PHPUnit_Framework_TestCase
+class PrettyPrinterTest extends TestCase
 {
     /**
      * @covers \phpDocumentor\Reflection\PrettyPrinter::pScalar_String


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^5.7`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.7.md#570---2016-12-02), that support this namespace.