### PR TITLE
Print more usefull error msg when no strategy matches

### DIFF
--- a/src/phpDocumentor/Reflection/Php/ProjectFactoryStrategies.php
+++ b/src/phpDocumentor/Reflection/Php/ProjectFactoryStrategies.php
@@ -55,7 +55,7 @@ final class ProjectFactoryStrategies implements StrategyContainer
         throw new OutOfBoundsException(
             sprintf(
                 'No matching factory found for %s',
-                is_object($object) ? get_class($object) : gettype($object)
+                is_object($object) ? get_class($object) : print_r($object, true)
             )
         );
     }


### PR DESCRIPTION
Before: OutOfBoundsException: No matching factory found for string
After: OutOfBoundsException: No matching factory found "the actual string"