### PR TITLE
Fixes none element docblock handling

### DIFF
--- a/src/phpDocumentor/Reflection/Php/Factory/File.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/File.php
@@ -164,7 +164,7 @@ final class File extends AbstractFactory implements ProjectFactoryStrategy
      * @param StrategyContainer $strategies
      * @param Context $context
      * @param Node[] $nodes
-     * @return null|\phpDocumentor\Reflection\Element
+     * @return null|\phpDocumentor\Reflection\DocBlock
      */
     protected function createFileDocBlock(
         Doc $docBlock = null,
@@ -174,12 +174,12 @@ final class File extends AbstractFactory implements ProjectFactoryStrategy
     ) {
         $node = current($nodes);
         if (!$node instanceof Node) {
-            return $docBlock;
+            return null;
         }
 
         $comments = $node->getAttribute('comments');
         if (!is_array($comments) || empty($comments)) {
-            return $docBlock;
+            return null;
         }
 
         $found = 0;
@@ -189,7 +189,13 @@ final class File extends AbstractFactory implements ProjectFactoryStrategy
                 continue;
             }
 
-            if ($node instanceof NamespaceNode) {
+            //If current node cannot have a docblock return the first comment as docblock for the file.
+            if (!(
+                $node instanceof ClassNode ||
+                $node instanceof FunctionNode ||
+                $node instanceof InterfaceNode ||
+                $node instanceof TraitNode
+            )) {
                 return $this->createDocBlock($strategies, $comment, $context);
             }
 
@@ -205,6 +211,6 @@ final class File extends AbstractFactory implements ProjectFactoryStrategy
             return $this->createDocBlock($strategies, $firstDocBlock, $context);
         }
 
-        return $docBlock;
+        return null;
     }
 }

--- a/tests/component/ProjectCreationTest.php
+++ b/tests/component/ProjectCreationTest.php
@@ -194,4 +194,15 @@ class ProjectCreationTest extends TestCase
 
         $this->assertEquals(new String_(),  $interface->getMethods()['\Packing::getName()']->getReturnType());
     }
+
+    public function testFileDocblock()
+    {
+        $fileName = __DIR__ . '/project/empty.php';
+        $project = $this->fixture->create('MyProject', [
+            new LocalFile($fileName)
+        ]);
+
+        $this->assertEquals("This file is part of phpDocumentor.", $project->getFiles()[$fileName]->getDocBlock()->getSummary());
+
+    }
 }

--- a/tests/component/project/empty.php
+++ b/tests/component/project/empty.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright 2015-2015 Mike van Riel<mike@phpdoc.org>
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+
+require "Pizza.php";


### PR DESCRIPTION
We made a mistake only accepting docblocks from namespaces for files.
This patch changes that, we know the types that are processed in a file
so look for those. If the first node is not in that list. The comment on the
first node is our file docblock.