### PR TITLE
Adds missing testcases and solves issue nullable

### DIFF
--- a/src/phpDocumentor/Reflection/Php/Factory/Function_.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Function_.php
@@ -22,6 +22,7 @@ use phpDocumentor\Reflection\Php\StrategyContainer;
 use phpDocumentor\Reflection\TypeResolver;
 use phpDocumentor\Reflection\Types\Context;
 use PhpParser\Comment\Doc;
+use PhpParser\Node\NullableType;
 use PhpParser\Node\Stmt\Function_ as FunctionNode;
 
 /**
@@ -59,9 +60,14 @@ final class Function_ extends AbstractFactory implements ProjectFactoryStrategy
         $docBlock = $this->createDocBlock($strategies, $object->getDocComment(), $context);
 
         $returnType = null;
-        if ($object->returnType !== null) {
+        if ($object->getReturnType() !== null) {
             $typeResolver = new TypeResolver();
-            $returnType = $typeResolver->resolve($object->returnType, $context);
+            if ($object->getReturnType() instanceof NullableType) {
+                $typeString = '?' . $object->getReturnType()->type;
+            } else {
+                $typeString = (string)$object->getReturnType();
+            }
+            $returnType = $typeResolver->resolve($typeString, $context);
         }
 
         $function = new FunctionDescriptor($object->fqsen, $docBlock, new Location($object->getLine()), $returnType);

--- a/src/phpDocumentor/Reflection/Php/Factory/Method.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Method.php
@@ -20,6 +20,7 @@ use phpDocumentor\Reflection\Php\Visibility;
 use phpDocumentor\Reflection\TypeResolver;
 use phpDocumentor\Reflection\Types\Context;
 use phpDocumentor\Reflection\Types\Mixed_;
+use PhpParser\Node\NullableType;
 use PhpParser\Node\Stmt\ClassMethod;
 
 /**
@@ -51,9 +52,14 @@ final class Method extends AbstractFactory implements ProjectFactoryStrategy
         $docBlock = $this->createDocBlock($strategies, $object->getDocComment(), $context);
 
         $returnType = null;
-        if ($object->returnType !== null) {
+        if ($object->getReturnType() !== null) {
             $typeResolver = new TypeResolver();
-            $returnType = $typeResolver->resolve($object->returnType, $context);
+            if ($object->getReturnType() instanceof NullableType) {
+                $typeString = '?' . $object->getReturnType()->type;
+            } else {
+                $typeString = (string)$object->getReturnType();
+            }
+            $returnType = $typeResolver->resolve($typeString, $context);
         }
 
         $method = new MethodDescriptor(


### PR DESCRIPTION
Nullable return types are an object type in php-parser this patch
changes the logic to convert that to a return type of phpdocumentor