### PR TITLE
Fix namespace handling for defines and namespaced constants

### DIFF
--- a/src/phpDocumentor/Reflection/Php/Factory/Define.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Define.php
@@ -26,6 +26,7 @@ use PhpParser\Node\Stmt\Expression;
 use PhpParser\PrettyPrinter\Standard as PrettyPrinter;
 use RuntimeException;
 use function sprintf;
+use function strpos;
 
 /**
  * Strategy to convert `define` expressions to ConstantElement
@@ -93,7 +94,7 @@ final class Define extends AbstractFactory
         [$name, $value] = $expression->args;
 
         return new ConstantElement(
-            $this->determineFqsen($context, $name),
+            $this->determineFqsen($name),
             $this->createDocBlock($strategies, $object->getDocComment(), $context),
             $this->determineValue($value),
             new Location($object->getLine())
@@ -109,16 +110,15 @@ final class Define extends AbstractFactory
         return $this->valueConverter->prettyPrintExpr($value->value);
     }
 
-    private function determineFqsen(?Context $context, Arg $name) : Fqsen
+    private function determineFqsen(Arg $name) : Fqsen
     {
         /** @var String_ $nameString */
         $nameString = $name->value;
-        $namespace = $context ? $context->getNamespace() : '';
 
-        if (empty($namespace)) {
+        if (strpos($nameString->value, '\\') === false) {
             return new Fqsen(sprintf('\\%s', $nameString->value));
         }
 
-        return new Fqsen(sprintf('\\%s\\%s', $namespace, $nameString->value));
+        return new Fqsen(sprintf('%s', $nameString->value));
     }
 }

--- a/src/phpDocumentor/Reflection/Php/ProjectFactory.php
+++ b/src/phpDocumentor/Reflection/Php/ProjectFactory.php
@@ -148,7 +148,8 @@ final class ProjectFactory implements ProjectFactoryInterface
         }
 
         foreach ($file->getConstants() as $constant) {
-            if ($namespace->getFqsen() . '::' . $constant->getName() !== (string) $constant->getFqsen()) {
+            if ($namespace->getFqsen() . '::' . $constant->getName() !== (string) $constant->getFqsen() &&
+                $namespace->getFqsen() . '\\' . $constant->getName() !== (string) $constant->getFqsen()) {
                 continue;
             }
 

--- a/tests/integration/ProjectCreationTest.php
+++ b/tests/integration/ProjectCreationTest.php
@@ -205,6 +205,7 @@ class ProjectCreationTest extends MockeryTestCase
 
         $this->assertArrayHasKey('\\Luigi\\OVEN_TEMPERATURE', $project->getFiles()[$fileName]->getConstants());
         $this->assertArrayHasKey('\\Luigi\\MAX_OVEN_TEMPERATURE', $project->getFiles()[$fileName]->getConstants());
+        $this->assertArrayHasKey('\\OUTSIDE_OVEN_TEMPERATURE', $project->getFiles()[$fileName]->getConstants());
     }
 
     public function testInterfaceExtends() : void

--- a/tests/integration/ProjectNamespaceTest.php
+++ b/tests/integration/ProjectNamespaceTest.php
@@ -49,4 +49,23 @@ class ProjectNamespaceTest extends TestCase
             $project->getNamespaces()['\\Luigi']->getClasses()
         );
     }
+
+    public function testWithNamespacedConstant() : void
+    {
+        $fileName = __DIR__ . '/data/Luigi/constants.php';
+        $project = $this->fixture->create(
+            'My Project',
+            [ new LocalFile($fileName) ]
+        );
+
+        $this->assertArrayHasKey($fileName, $project->getFiles());
+        $this->assertArrayHasKey('\\Luigi', $project->getNamespaces());
+        $this->assertEquals(
+            [
+                '\\Luigi\\OVEN_TEMPERATURE' => new Fqsen('\\Luigi\\OVEN_TEMPERATURE'),
+                '\\Luigi\\MAX_OVEN_TEMPERATURE' => new Fqsen('\\Luigi\\MAX_OVEN_TEMPERATURE'),
+                ],
+            $project->getNamespaces()['\\Luigi']->getConstants()
+        );
+    }
 }

--- a/tests/integration/data/Luigi/constants.php
+++ b/tests/integration/data/Luigi/constants.php
@@ -3,4 +3,5 @@
 namespace Luigi;
 
 const OVEN_TEMPERATURE = 9001;
-define('MAX_OVEN_TEMPERATURE', 9002);
+define('\\Luigi\\MAX_OVEN_TEMPERATURE', 9002);
+define('OUTSIDE_OVEN_TEMPERATURE', 9002);

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/DefineTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/DefineTest.php
@@ -64,10 +64,24 @@ final class DefineTest extends TestCase
         $constant = $this->fixture->create(
             $constantStub,
             new ProjectFactoryStrategies([]),
-            new Context('Space\MyClass')
+            new Context('Space\\MyClass')
         );
 
-        $this->assertConstant($constant, '\\Space\\MyClass');
+        $this->assertConstant($constant, '');
+    }
+
+    public function testCreateNamespace() : void
+    {
+        $constantStub = $this->buildDefineStub('\\OtherSpace\\MyClass');
+
+        /** @var ConstantDescriptor $constant */
+        $constant = $this->fixture->create(
+            $constantStub,
+            new ProjectFactoryStrategies([]),
+            new Context('Space\\MyClass')
+        );
+
+        $this->assertConstant($constant, '\\OtherSpace\\MyClass');
     }
 
     public function testCreateGlobal() : void
@@ -99,7 +113,7 @@ final class DefineTest extends TestCase
             ),
             ['comments' => [$doc]]
         );
-        $context = new Context('Space\MyClass');
+        $context = new Context('Space\\MyClass');
 
         $strategyMock = m::mock(ProjectFactoryStrategy::class);
         $containerMock = m::mock(StrategyContainer::class);
@@ -119,17 +133,17 @@ final class DefineTest extends TestCase
             $context
         );
 
-        $this->assertConstant($constant, '\\Space\\MyClass');
+        $this->assertConstant($constant, '');
         $this->assertSame($docBlock, $constant->getDocBlock());
     }
 
-    private function buildDefineStub() : Expression
+    private function buildDefineStub($namespace = '') : Expression
     {
         return new Expression(
             new FuncCall(
                 new Name('define'),
                 [
-                    new Arg(new String_('MY_CONST1')),
+                    new Arg(new String_($namespace ?  $namespace . '\\MY_CONST1' : 'MY_CONST1')),
                     new Arg(new String_('a')),
                 ]
             )


### PR DESCRIPTION
Solves #156 

Handling `define(__NAMESPACE__ . '\\NS_CONST')` is not part of this.