### PR TITLE
CS update after upstream changes

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,22 +1,29 @@
 <?xml version="1.0"?>
-<ruleset name="phpDocumentor">
- <description>The coding standard for phpDocumentor.</description>
+<ruleset name="Reflection">
+ <description>The coding standard for this library.</description>
 
     <file>src</file>
     <file>tests/unit</file>
-    <exclude-pattern>*/tests/unit/Types/ContextFactoryTest.php</exclude-pattern>
+    <exclude-pattern>*/tests/unit/Types/ContextFactoryTest\.php</exclude-pattern>
     <arg value="p"/>
+
+    <!-- Set the minimum PHP version for PHPCompatibility.
+         This should be kept in sync with the requirements in the composer.json file. -->
+    <config name="testVersion" value="7.2-"/>
 
     <rule ref="phpDocumentor">
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint" />
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint" />
+
+        <!-- Property type declarations are a PHP 7.4 feature. -->
+        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint"/>
     </rule>
 
     <rule ref="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming.SuperfluousPrefix">
-        <exclude-pattern>*/src/*/Abstract*.php</exclude-pattern>
+        <exclude-pattern>*/src/*/Abstract*\.php</exclude-pattern>
     </rule>
 
     <rule ref="SlevomatCodingStandard.Functions.StaticClosure.ClosureNotStatic">
-        <exclude-pattern>*/tests/unit/**</exclude-pattern>
+        <exclude-pattern>*/tests/unit/*</exclude-pattern>
     </rule>
 </ruleset>

--- a/src/phpDocumentor/Reflection/File/LocalFile.php
+++ b/src/phpDocumentor/Reflection/File/LocalFile.php
@@ -15,6 +15,7 @@ namespace phpDocumentor\Reflection\File;
 
 use InvalidArgumentException;
 use phpDocumentor\Reflection\File;
+
 use function file_exists;
 use function file_get_contents;
 use function md5_file;

--- a/src/phpDocumentor/Reflection/File/LocalFile.php
+++ b/src/phpDocumentor/Reflection/File/LocalFile.php
@@ -44,7 +44,7 @@ final class LocalFile implements File
     /**
      * Returns the content of the file as a string.
      */
-    public function getContents() : string
+    public function getContents(): string
     {
         return (string) file_get_contents($this->path);
     }
@@ -52,7 +52,7 @@ final class LocalFile implements File
     /**
      * Returns md5 hash of the file.
      */
-    public function md5() : string
+    public function md5(): string
     {
         return md5_file($this->path);
     }
@@ -60,7 +60,7 @@ final class LocalFile implements File
     /**
      * Returns an relative path to the file.
      */
-    public function path() : string
+    public function path(): string
     {
         return $this->path;
     }

--- a/src/phpDocumentor/Reflection/Middleware/ChainFactory.php
+++ b/src/phpDocumentor/Reflection/Middleware/ChainFactory.php
@@ -25,7 +25,7 @@ final class ChainFactory
     /**
      * @param Middleware[] $middlewareList
      */
-    public static function createExecutionChain(array $middlewareList, callable $lastCallable) : callable
+    public static function createExecutionChain(array $middlewareList, callable $lastCallable): callable
     {
         while ($middleware = array_pop($middlewareList)) {
             if (!$middleware instanceof Middleware) {

--- a/src/phpDocumentor/Reflection/Middleware/ChainFactory.php
+++ b/src/phpDocumentor/Reflection/Middleware/ChainFactory.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Reflection\Middleware;
 
 use InvalidArgumentException;
+
 use function array_pop;
 use function get_class;
 use function gettype;

--- a/src/phpDocumentor/Reflection/Middleware/Middleware.php
+++ b/src/phpDocumentor/Reflection/Middleware/Middleware.php
@@ -23,5 +23,5 @@ interface Middleware
      *
      * @param callable(Command): object $next
      */
-    public function execute(Command $command, callable $next) : object;
+    public function execute(Command $command, callable $next): object;
 }

--- a/src/phpDocumentor/Reflection/NodeVisitor/ElementNameResolver.php
+++ b/src/phpDocumentor/Reflection/NodeVisitor/ElementNameResolver.php
@@ -27,6 +27,7 @@ use PhpParser\Node\Stmt\Trait_;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
 use SplDoublyLinkedList;
+
 use function get_class;
 use function rtrim;
 

--- a/src/phpDocumentor/Reflection/NodeVisitor/ElementNameResolver.php
+++ b/src/phpDocumentor/Reflection/NodeVisitor/ElementNameResolver.php
@@ -110,11 +110,13 @@ final class ElementNameResolver extends NodeVisitorAbstract
                 $node->fqsen = new Fqsen($this->buildName());
 
                 return NodeTraverser::DONT_TRAVERSE_CHILDREN;
+
             case ClassMethod::class:
                 $this->parts->push('::' . $node->name . '()');
                 $node->fqsen = new Fqsen($this->buildName());
 
                 return NodeTraverser::DONT_TRAVERSE_CHILDREN;
+
             case ClassConst::class:
                 $this->parts->push('::');
                 break;

--- a/src/phpDocumentor/Reflection/NodeVisitor/ElementNameResolver.php
+++ b/src/phpDocumentor/Reflection/NodeVisitor/ElementNameResolver.php
@@ -83,7 +83,7 @@ final class ElementNameResolver extends NodeVisitorAbstract
      *       that should clear up the PHPSTAN errors about
      *       "access to an undefined property ::$fqsen".
      */
-    public function enterNode(Node $node) : ?int
+    public function enterNode(Node $node): ?int
     {
         switch (get_class($node)) {
             case Namespace_::class:
@@ -133,7 +133,7 @@ final class ElementNameResolver extends NodeVisitorAbstract
     /**
      * Resets the state of the object to an empty state.
      */
-    private function resetState(?string $namespace = null) : void
+    private function resetState(?string $namespace = null): void
     {
         $this->parts = new SplDoublyLinkedList();
         $this->parts->push($namespace);
@@ -142,7 +142,7 @@ final class ElementNameResolver extends NodeVisitorAbstract
     /**
      * Builds the name of the current node using the parts that are pushed to the parts list.
      */
-    private function buildName() : string
+    private function buildName(): string
     {
         $name = null;
         foreach ($this->parts as $part) {

--- a/src/phpDocumentor/Reflection/Php/Argument.php
+++ b/src/phpDocumentor/Reflection/Php/Argument.php
@@ -60,27 +60,27 @@ final class Argument
     /**
      * Returns the name of this argument.
      */
-    public function getName() : string
+    public function getName(): string
     {
         return $this->name;
     }
 
-    public function getType() : ?Type
+    public function getType(): ?Type
     {
         return $this->type;
     }
 
-    public function getDefault() : ?string
+    public function getDefault(): ?string
     {
         return $this->default;
     }
 
-    public function isByReference() : bool
+    public function isByReference(): bool
     {
         return $this->byReference;
     }
 
-    public function isVariadic() : bool
+    public function isVariadic(): bool
     {
         return $this->isVariadic;
     }

--- a/src/phpDocumentor/Reflection/Php/Class_.php
+++ b/src/phpDocumentor/Reflection/Php/Class_.php
@@ -84,7 +84,7 @@ final class Class_ implements Element
     /**
      * Returns true when this class is final. Otherwise returns false.
      */
-    public function isFinal() : bool
+    public function isFinal(): bool
     {
         return $this->final;
     }
@@ -92,7 +92,7 @@ final class Class_ implements Element
     /**
      * Returns true when this class is abstract. Otherwise returns false.
      */
-    public function isAbstract() : bool
+    public function isAbstract(): bool
     {
         return $this->abstract;
     }
@@ -100,7 +100,7 @@ final class Class_ implements Element
     /**
      * Returns the superclass this class is extending if available.
      */
-    public function getParent() : ?Fqsen
+    public function getParent(): ?Fqsen
     {
         return $this->parent;
     }
@@ -110,7 +110,7 @@ final class Class_ implements Element
      *
      * @return Fqsen[]
      */
-    public function getInterfaces() : array
+    public function getInterfaces(): array
     {
         return $this->implements;
     }
@@ -118,7 +118,7 @@ final class Class_ implements Element
     /**
      * Add a interface Fqsen this class is implementing.
      */
-    public function addInterface(Fqsen $interface) : void
+    public function addInterface(Fqsen $interface): void
     {
         $this->implements[(string) $interface] = $interface;
     }
@@ -128,7 +128,7 @@ final class Class_ implements Element
      *
      * @return Constant[]
      */
-    public function getConstants() : array
+    public function getConstants(): array
     {
         return $this->constants;
     }
@@ -136,7 +136,7 @@ final class Class_ implements Element
     /**
      * Add Constant to this class.
      */
-    public function addConstant(Constant $constant) : void
+    public function addConstant(Constant $constant): void
     {
         $this->constants[(string) $constant->getFqsen()] = $constant;
     }
@@ -146,7 +146,7 @@ final class Class_ implements Element
      *
      * @return Method[]
      */
-    public function getMethods() : array
+    public function getMethods(): array
     {
         return $this->methods;
     }
@@ -154,7 +154,7 @@ final class Class_ implements Element
     /**
      * Add a method to this class.
      */
-    public function addMethod(Method $method) : void
+    public function addMethod(Method $method): void
     {
         $this->methods[(string) $method->getFqsen()] = $method;
     }
@@ -164,7 +164,7 @@ final class Class_ implements Element
      *
      * @return Property[]
      */
-    public function getProperties() : array
+    public function getProperties(): array
     {
         return $this->properties;
     }
@@ -172,7 +172,7 @@ final class Class_ implements Element
     /**
      * Add a property to this class.
      */
-    public function addProperty(Property $property) : void
+    public function addProperty(Property $property): void
     {
         $this->properties[(string) $property->getFqsen()] = $property;
     }
@@ -182,7 +182,7 @@ final class Class_ implements Element
      *
      * @return Fqsen[]
      */
-    public function getUsedTraits() : array
+    public function getUsedTraits(): array
     {
         return $this->usedTraits;
     }
@@ -190,7 +190,7 @@ final class Class_ implements Element
     /**
      * Add trait fqsen used by this class.
      */
-    public function addUsedTrait(Fqsen $fqsen) : void
+    public function addUsedTrait(Fqsen $fqsen): void
     {
         $this->usedTraits[(string) $fqsen] = $fqsen;
     }
@@ -198,7 +198,7 @@ final class Class_ implements Element
     /**
      * Returns the Fqsen of the element.
      */
-    public function getFqsen() : Fqsen
+    public function getFqsen(): Fqsen
     {
         return $this->fqsen;
     }
@@ -206,17 +206,17 @@ final class Class_ implements Element
     /**
      * Returns the name of the element.
      */
-    public function getName() : string
+    public function getName(): string
     {
         return $this->fqsen->getName();
     }
 
-    public function getDocBlock() : ?DocBlock
+    public function getDocBlock(): ?DocBlock
     {
         return $this->docBlock;
     }
 
-    public function getLocation() : Location
+    public function getLocation(): Location
     {
         return $this->location;
     }

--- a/src/phpDocumentor/Reflection/Php/Constant.php
+++ b/src/phpDocumentor/Reflection/Php/Constant.php
@@ -58,7 +58,7 @@ final class Constant implements Element
     /**
      * Returns the value of this constant.
      */
-    public function getValue() : ?string
+    public function getValue(): ?string
     {
         return $this->value;
     }
@@ -66,7 +66,7 @@ final class Constant implements Element
     /**
      * Returns the Fqsen of the element.
      */
-    public function getFqsen() : Fqsen
+    public function getFqsen(): Fqsen
     {
         return $this->fqsen;
     }
@@ -74,7 +74,7 @@ final class Constant implements Element
     /**
      * Returns the name of the element.
      */
-    public function getName() : string
+    public function getName(): string
     {
         return $this->fqsen->getName();
     }
@@ -82,17 +82,17 @@ final class Constant implements Element
     /**
      * Returns DocBlock of this constant if available.
      */
-    public function getDocBlock() : ?DocBlock
+    public function getDocBlock(): ?DocBlock
     {
         return $this->docBlock;
     }
 
-    public function getLocation() : Location
+    public function getLocation(): Location
     {
         return $this->location;
     }
 
-    public function getVisibility() : Visibility
+    public function getVisibility(): Visibility
     {
         return $this->visibility;
     }

--- a/src/phpDocumentor/Reflection/Php/Factory/AbstractFactory.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/AbstractFactory.php
@@ -12,6 +12,7 @@ use phpDocumentor\Reflection\Php\StrategyContainer;
 use phpDocumentor\Reflection\Types\Context;
 use PhpParser\Comment\Doc;
 use PhpParser\NodeAbstract;
+
 use function get_class;
 use function gettype;
 use function is_object;

--- a/src/phpDocumentor/Reflection/Php/Factory/AbstractFactory.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/AbstractFactory.php
@@ -32,9 +32,9 @@ abstract class AbstractFactory implements ProjectFactoryStrategy
      *
      * @param object $object object to check.
      */
-    abstract public function matches(ContextStack $context, object $object) : bool;
+    abstract public function matches(ContextStack $context, object $object): bool;
 
-    public function create(ContextStack $context, object $object, StrategyContainer $strategies) : void
+    public function create(ContextStack $context, object $object, StrategyContainer $strategies): void
     {
         if (!$this->matches($context, $object)) {
             throw new InvalidArgumentException(
@@ -57,9 +57,9 @@ abstract class AbstractFactory implements ProjectFactoryStrategy
      *
      * @param NodeAbstract|object $object object to convert to an Element
      */
-    abstract protected function doCreate(ContextStack $context, object $object, StrategyContainer $strategies) : void;
+    abstract protected function doCreate(ContextStack $context, object $object, StrategyContainer $strategies): void;
 
-    protected function createDocBlock(?Doc $docBlock = null, ?Context $context = null) : ?DocBlock
+    protected function createDocBlock(?Doc $docBlock = null, ?Context $context = null): ?DocBlock
     {
         if ($docBlock === null) {
             return null;

--- a/src/phpDocumentor/Reflection/Php/Factory/Argument.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Argument.php
@@ -42,7 +42,7 @@ final class Argument extends AbstractFactory implements ProjectFactoryStrategy
         $this->valueConverter = $prettyPrinter;
     }
 
-    public function matches(ContextStack $context, object $object) : bool
+    public function matches(ContextStack $context, object $object): bool
     {
         return $object instanceof Param;
     }
@@ -61,7 +61,7 @@ final class Argument extends AbstractFactory implements ProjectFactoryStrategy
         ContextStack $context,
         object $object,
         StrategyContainer $strategies
-    ) : void {
+    ): void {
         Assert::isInstanceOf($object, Param::class);
         Assert::isInstanceOf($object->var, Variable::class);
 

--- a/src/phpDocumentor/Reflection/Php/Factory/ClassConstant.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/ClassConstant.php
@@ -41,7 +41,7 @@ final class ClassConstant extends AbstractFactory
         parent::__construct($blockFactory);
     }
 
-    public function matches(ContextStack $context, object $object) : bool
+    public function matches(ContextStack $context, object $object): bool
     {
         return $object instanceof ClassConst;
     }
@@ -60,7 +60,7 @@ final class ClassConstant extends AbstractFactory
         ContextStack $context,
         object $object,
         StrategyContainer $strategies
-    ) : void {
+    ): void {
         $constantContainer = $context->peek();
         Assert::isInstanceOfAny(
             $constantContainer,
@@ -86,7 +86,7 @@ final class ClassConstant extends AbstractFactory
     /**
      * Converts the visibility of the constant to a valid Visibility object.
      */
-    private function buildVisibility(ClassConstantIterator $node) : Visibility
+    private function buildVisibility(ClassConstantIterator $node): Visibility
     {
         if ($node->isPrivate()) {
             return new Visibility(Visibility::PRIVATE_);

--- a/src/phpDocumentor/Reflection/Php/Factory/ClassConstantIterator.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/ClassConstantIterator.php
@@ -44,7 +44,7 @@ final class ClassConstantIterator implements Iterator
      *
      * @return int Line
      */
-    public function getLine() : int
+    public function getLine(): int
     {
         return $this->classConstants->getLine();
     }
@@ -52,7 +52,7 @@ final class ClassConstantIterator implements Iterator
     /**
      * Returns the name of the current constant.
      */
-    public function getName() : string
+    public function getName(): string
     {
         return (string) $this->classConstants->consts[$this->index]->name;
     }
@@ -60,7 +60,7 @@ final class ClassConstantIterator implements Iterator
     /**
      * Returns the fqsen of the current constant.
      */
-    public function getFqsen() : Fqsen
+    public function getFqsen(): Fqsen
     {
         return $this->classConstants->consts[$this->index]->fqsen;
     }
@@ -68,7 +68,7 @@ final class ClassConstantIterator implements Iterator
     /**
      * returns true when the current property is public.
      */
-    public function isPublic() : bool
+    public function isPublic(): bool
     {
         return $this->classConstants->isPublic();
     }
@@ -76,7 +76,7 @@ final class ClassConstantIterator implements Iterator
     /**
      * returns true when the current property is protected.
      */
-    public function isProtected() : bool
+    public function isProtected(): bool
     {
         return $this->classConstants->isProtected();
     }
@@ -84,7 +84,7 @@ final class ClassConstantIterator implements Iterator
     /**
      * returns true when the current property is private.
      */
-    public function isPrivate() : bool
+    public function isPrivate(): bool
     {
         return $this->classConstants->isPrivate();
     }
@@ -94,7 +94,7 @@ final class ClassConstantIterator implements Iterator
      *
      * The doc comment has to be the last comment associated with the node.
      */
-    public function getDocComment() : ?Doc
+    public function getDocComment(): ?Doc
     {
         $docComment = $this->classConstants->consts[$this->index]->getDocComment();
         if ($docComment === null) {
@@ -104,7 +104,7 @@ final class ClassConstantIterator implements Iterator
         return $docComment;
     }
 
-    public function getValue() : Expr
+    public function getValue(): Expr
     {
         return $this->classConstants->consts[$this->index]->value;
     }
@@ -112,7 +112,7 @@ final class ClassConstantIterator implements Iterator
     /**
      * @link http://php.net/manual/en/iterator.current.php
      */
-    public function current() : self
+    public function current(): self
     {
         return $this;
     }
@@ -120,7 +120,7 @@ final class ClassConstantIterator implements Iterator
     /**
      * @link http://php.net/manual/en/iterator.next.php
      */
-    public function next() : void
+    public function next(): void
     {
         ++$this->index;
     }
@@ -128,7 +128,7 @@ final class ClassConstantIterator implements Iterator
     /**
      * @link http://php.net/manual/en/iterator.key.php
      */
-    public function key() : ?int
+    public function key(): ?int
     {
         return $this->index;
     }
@@ -136,7 +136,7 @@ final class ClassConstantIterator implements Iterator
     /**
      * @link http://php.net/manual/en/iterator.valid.php
      */
-    public function valid() : bool
+    public function valid(): bool
     {
         return isset($this->classConstants->consts[$this->index]);
     }
@@ -144,7 +144,7 @@ final class ClassConstantIterator implements Iterator
     /**
      * @link http://php.net/manual/en/iterator.rewind.php
      */
-    public function rewind() : void
+    public function rewind(): void
     {
         $this->index = 0;
     }

--- a/src/phpDocumentor/Reflection/Php/Factory/Class_.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Class_.php
@@ -27,7 +27,7 @@ use function assert;
  */
 final class Class_ extends AbstractFactory implements ProjectFactoryStrategy
 {
-    public function matches(ContextStack $context, object $object) : bool
+    public function matches(ContextStack $context, object $object): bool
     {
         return $object instanceof ClassNode;
     }
@@ -41,7 +41,7 @@ final class Class_ extends AbstractFactory implements ProjectFactoryStrategy
      * @param ContextStack $context of the created object
      * @param ClassNode $object
      */
-    protected function doCreate(ContextStack $context, object $object, StrategyContainer $strategies) : void
+    protected function doCreate(ContextStack $context, object $object, StrategyContainer $strategies): void
     {
         $docBlock = $this->createDocBlock($object->getDocComment(), $context->getTypeContext());
 

--- a/src/phpDocumentor/Reflection/Php/Factory/Class_.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Class_.php
@@ -20,6 +20,7 @@ use phpDocumentor\Reflection\Php\File as FileElement;
 use phpDocumentor\Reflection\Php\ProjectFactoryStrategy;
 use phpDocumentor\Reflection\Php\StrategyContainer;
 use PhpParser\Node\Stmt\Class_ as ClassNode;
+
 use function assert;
 
 /**

--- a/src/phpDocumentor/Reflection/Php/Factory/ConstructorPromotion.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/ConstructorPromotion.php
@@ -37,7 +37,7 @@ class ConstructorPromotion extends AbstractFactory
         $this->methodStrategy = $methodStrategy;
     }
 
-    public function matches(ContextStack $context, object $object) : bool
+    public function matches(ContextStack $context, object $object): bool
     {
         try {
             return $context->peek() instanceof ClassElement &&
@@ -51,7 +51,7 @@ class ConstructorPromotion extends AbstractFactory
     /**
      * @param ClassMethod $object
      */
-    protected function doCreate(ContextStack $context, object $object, StrategyContainer $strategies) : void
+    protected function doCreate(ContextStack $context, object $object, StrategyContainer $strategies): void
     {
         $this->methodStrategy->create($context, $object, $strategies);
 
@@ -64,7 +64,7 @@ class ConstructorPromotion extends AbstractFactory
         }
     }
 
-    private function promoteParameterToProperty(ContextStack $context, Param $param) : void
+    private function promoteParameterToProperty(ContextStack $context, Param $param): void
     {
         $methodContainer = $context->peek();
         Assert::isInstanceOf($methodContainer, ClassElement::class);
@@ -83,7 +83,7 @@ class ConstructorPromotion extends AbstractFactory
         $methodContainer->addProperty($property);
     }
 
-    private function buildPropertyVisibilty(int $flags) : Visibility
+    private function buildPropertyVisibilty(int $flags): Visibility
     {
         if ((bool) ($flags & Class_::MODIFIER_PRIVATE) === true) {
             return new Visibility(Visibility::PRIVATE_);

--- a/src/phpDocumentor/Reflection/Php/Factory/ContextStack.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/ContextStack.php
@@ -9,6 +9,7 @@ use phpDocumentor\Reflection\Element;
 use phpDocumentor\Reflection\Php\File as FileElement;
 use phpDocumentor\Reflection\Php\Project;
 use phpDocumentor\Reflection\Types\Context as TypeContext;
+
 use function end;
 
 final class ContextStack

--- a/src/phpDocumentor/Reflection/Php/Factory/ContextStack.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/ContextStack.php
@@ -28,7 +28,7 @@ final class ContextStack
     }
 
     /** @param (Element|FileElement)[] $elements */
-    private static function createFromSelf(Project $project, ?TypeContext $typeContext, array $elements) : self
+    private static function createFromSelf(Project $project, ?TypeContext $typeContext, array $elements): self
     {
         $self = new self($project, $typeContext);
         $self->elements = $elements;
@@ -37,7 +37,7 @@ final class ContextStack
     }
 
     /** @param  Element|FileElement $element */
-    public function push($element) : self
+    public function push($element): self
     {
         $elements = $this->elements;
         $elements[] = $element;
@@ -45,17 +45,17 @@ final class ContextStack
         return self::createFromSelf($this->project, $this->typeContext, $elements);
     }
 
-    public function withTypeContext(TypeContext $typeContext) : ContextStack
+    public function withTypeContext(TypeContext $typeContext): ContextStack
     {
         return self::createFromSelf($this->project, $typeContext, $this->elements);
     }
 
-    public function getTypeContext() : ?TypeContext
+    public function getTypeContext(): ?TypeContext
     {
         return $this->typeContext;
     }
 
-    public function getProject() : Project
+    public function getProject(): Project
     {
         return $this->project;
     }

--- a/src/phpDocumentor/Reflection/Php/Factory/Define.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Define.php
@@ -26,6 +26,7 @@ use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\PrettyPrinter\Standard as PrettyPrinter;
 use RuntimeException;
+
 use function assert;
 use function sprintf;
 use function strpos;

--- a/src/phpDocumentor/Reflection/Php/Factory/Define.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Define.php
@@ -50,7 +50,7 @@ final class Define extends AbstractFactory
         $this->valueConverter = $prettyPrinter;
     }
 
-    public function matches(ContextStack $context, object $object) : bool
+    public function matches(ContextStack $context, object $object): bool
     {
         if (!$object instanceof Expression) {
             return false;
@@ -81,7 +81,7 @@ final class Define extends AbstractFactory
         ContextStack $context,
         object $object,
         StrategyContainer $strategies
-    ) : void {
+    ): void {
         $expression = $object->expr;
         if (!$expression instanceof FuncCall) {
             throw new RuntimeException(
@@ -105,7 +105,7 @@ final class Define extends AbstractFactory
         $file->addConstant($constant);
     }
 
-    private function determineValue(?Arg $value) : ?string
+    private function determineValue(?Arg $value): ?string
     {
         if ($value === null) {
             return null;
@@ -114,7 +114,7 @@ final class Define extends AbstractFactory
         return $this->valueConverter->prettyPrintExpr($value->value);
     }
 
-    private function determineFqsen(Arg $name) : Fqsen
+    private function determineFqsen(Arg $name): Fqsen
     {
         $nameString = $name->value;
         assert($nameString instanceof String_);

--- a/src/phpDocumentor/Reflection/Php/Factory/File.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/File.php
@@ -73,7 +73,7 @@ final class File extends AbstractFactory
         $this->middlewareChain = ChainFactory::createExecutionChain($middleware, $lastCallable);
     }
 
-    public function matches(ContextStack $context, object $object) : bool
+    public function matches(ContextStack $context, object $object): bool
     {
         return $object instanceof FileSystemFile;
     }
@@ -88,7 +88,7 @@ final class File extends AbstractFactory
      * @param FileSystemFile $object path to the file to convert to an File object.
      * @param StrategyContainer $strategies used to convert nested objects.
      */
-    protected function doCreate(ContextStack $context, object $object, StrategyContainer $strategies) : void
+    protected function doCreate(ContextStack $context, object $object, StrategyContainer $strategies): void
     {
         $command = new CreateCommand($context, $object, $strategies);
         $middlewareChain = $this->middlewareChain;
@@ -101,7 +101,7 @@ final class File extends AbstractFactory
         $context->getProject()->addFile($file);
     }
 
-    private function createFile(CreateCommand $command) : FileElement
+    private function createFile(CreateCommand $command): FileElement
     {
         $file = $command->getFile();
         $code = $file->getContents();
@@ -128,7 +128,7 @@ final class File extends AbstractFactory
         ContextStack $contextStack,
         array $nodes,
         StrategyContainer $strategies
-    ) : void {
+    ): void {
         foreach ($nodes as $node) {
             $strategy = $strategies->findMatching($contextStack, $node);
             $strategy->create($contextStack, $node, $strategies);
@@ -141,7 +141,7 @@ final class File extends AbstractFactory
     protected function createFileDocBlock(
         ?Context $context = null,
         array $nodes = []
-    ) : ?DocBlockInstance {
+    ): ?DocBlockInstance {
         $node = null;
         foreach ($nodes as $n) {
             if (!in_array(get_class($n), self::SKIPPED_NODE_TYPES)) {

--- a/src/phpDocumentor/Reflection/Php/Factory/File.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/File.php
@@ -168,13 +168,15 @@ final class File extends AbstractFactory
             }
 
             // If current node cannot have a docblock return the first comment as docblock for the file.
-            if (!(
+            if (
+                !(
                 $node instanceof ConstantNode ||
                 $node instanceof ClassNode ||
                 $node instanceof FunctionNode ||
                 $node instanceof InterfaceNode ||
                 $node instanceof TraitNode
-            )) {
+                )
+            ) {
                 return $this->createDocBlock($comment, $context);
             }
 

--- a/src/phpDocumentor/Reflection/Php/Factory/File.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/File.php
@@ -32,6 +32,7 @@ use PhpParser\Node\Stmt\Function_ as FunctionNode;
 use PhpParser\Node\Stmt\InlineHTML;
 use PhpParser\Node\Stmt\Interface_ as InterfaceNode;
 use PhpParser\Node\Stmt\Trait_ as TraitNode;
+
 use function get_class;
 use function in_array;
 use function is_array;

--- a/src/phpDocumentor/Reflection/Php/Factory/File/CreateCommand.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/File/CreateCommand.php
@@ -46,17 +46,17 @@ final class CreateCommand implements Command
     /**
      * Returns the strategyContainer in this command context.
      */
-    public function getStrategies() : StrategyContainer
+    public function getStrategies(): StrategyContainer
     {
         return $this->strategies;
     }
 
-    public function getFile() : File
+    public function getFile(): File
     {
         return $this->file;
     }
 
-    public function getContext() : ContextStack
+    public function getContext(): ContextStack
     {
         return $this->context;
     }

--- a/src/phpDocumentor/Reflection/Php/Factory/Function_.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Function_.php
@@ -29,7 +29,7 @@ use Webmozart\Assert\Assert;
  */
 final class Function_ extends AbstractFactory implements ProjectFactoryStrategy
 {
-    public function matches(ContextStack $context, object $object) : bool
+    public function matches(ContextStack $context, object $object): bool
     {
         return $object instanceof FunctionNode;
     }
@@ -44,7 +44,7 @@ final class Function_ extends AbstractFactory implements ProjectFactoryStrategy
         ContextStack $context,
         object $object,
         StrategyContainer $strategies
-    ) : void {
+    ): void {
         $file = $context->peek();
         Assert::isInstanceOf($file, FileElement::class);
 

--- a/src/phpDocumentor/Reflection/Php/Factory/GlobalConstant.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/GlobalConstant.php
@@ -42,7 +42,7 @@ final class GlobalConstant extends AbstractFactory
         parent::__construct($docBlockFactory);
     }
 
-    public function matches(ContextStack $context, object $object) : bool
+    public function matches(ContextStack $context, object $object): bool
     {
         return $object instanceof Const_;
     }
@@ -61,7 +61,7 @@ final class GlobalConstant extends AbstractFactory
         ContextStack $context,
         object $object,
         StrategyContainer $strategies
-    ) : void {
+    ): void {
         $constants = new GlobalConstantIterator($object);
         $file = $context->peek();
         Assert::isInstanceOf($file, FileElement::class);

--- a/src/phpDocumentor/Reflection/Php/Factory/GlobalConstantIterator.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/GlobalConstantIterator.php
@@ -40,7 +40,7 @@ final class GlobalConstantIterator implements Iterator
      *
      * @return int Line
      */
-    public function getLine() : int
+    public function getLine(): int
     {
         return $this->constant->getLine();
     }
@@ -48,7 +48,7 @@ final class GlobalConstantIterator implements Iterator
     /**
      * Returns the name of the current constant.
      */
-    public function getName() : string
+    public function getName(): string
     {
         return (string) $this->constant->consts[$this->index]->name;
     }
@@ -56,7 +56,7 @@ final class GlobalConstantIterator implements Iterator
     /**
      * Returns the fqsen of the current constant.
      */
-    public function getFqsen() : Fqsen
+    public function getFqsen(): Fqsen
     {
         return $this->constant->consts[$this->index]->fqsen;
     }
@@ -66,7 +66,7 @@ final class GlobalConstantIterator implements Iterator
      *
      * The doc comment has to be the last comment associated with the node.
      */
-    public function getDocComment() : ?Doc
+    public function getDocComment(): ?Doc
     {
         $docComment = $this->constant->consts[$this->index]->getDocComment();
         if ($docComment === null) {
@@ -76,7 +76,7 @@ final class GlobalConstantIterator implements Iterator
         return $docComment;
     }
 
-    public function getValue() : Expr
+    public function getValue(): Expr
     {
         return $this->constant->consts[$this->index]->value;
     }
@@ -84,7 +84,7 @@ final class GlobalConstantIterator implements Iterator
     /**
      * @link http://php.net/manual/en/iterator.current.php
      */
-    public function current() : self
+    public function current(): self
     {
         return $this;
     }
@@ -92,7 +92,7 @@ final class GlobalConstantIterator implements Iterator
     /**
      * @link http://php.net/manual/en/iterator.next.php
      */
-    public function next() : void
+    public function next(): void
     {
         ++$this->index;
     }
@@ -100,7 +100,7 @@ final class GlobalConstantIterator implements Iterator
     /**
      * @link http://php.net/manual/en/iterator.key.php
      */
-    public function key() : ?int
+    public function key(): ?int
     {
         return $this->index;
     }
@@ -108,7 +108,7 @@ final class GlobalConstantIterator implements Iterator
     /**
      * @link http://php.net/manual/en/iterator.valid.php
      */
-    public function valid() : bool
+    public function valid(): bool
     {
         return isset($this->constant->consts[$this->index]);
     }
@@ -116,7 +116,7 @@ final class GlobalConstantIterator implements Iterator
     /**
      * @link http://php.net/manual/en/iterator.rewind.php
      */
-    public function rewind() : void
+    public function rewind(): void
     {
         $this->index = 0;
     }

--- a/src/phpDocumentor/Reflection/Php/Factory/IfStatement.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/IfStatement.php
@@ -11,7 +11,7 @@ use PhpParser\Node\Stmt\If_;
 
 class IfStatement implements ProjectFactoryStrategy
 {
-    public function matches(ContextStack $context, object $object) : bool
+    public function matches(ContextStack $context, object $object): bool
     {
         return $object instanceof If_;
     }
@@ -19,7 +19,7 @@ class IfStatement implements ProjectFactoryStrategy
     /**
      * @param If_ $object
      */
-    public function create(ContextStack $context, object $object, StrategyContainer $strategies) : void
+    public function create(ContextStack $context, object $object, StrategyContainer $strategies): void
     {
         foreach ($object->stmts as $stmt) {
             $strategies->findMatching($context, $stmt)->create($context, $stmt, $strategies);

--- a/src/phpDocumentor/Reflection/Php/Factory/Interface_.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Interface_.php
@@ -27,7 +27,7 @@ use Webmozart\Assert\Assert;
  */
 final class Interface_ extends AbstractFactory implements ProjectFactoryStrategy
 {
-    public function matches(ContextStack $context, object $object) : bool
+    public function matches(ContextStack $context, object $object): bool
     {
         return $object instanceof InterfaceNode;
     }
@@ -46,7 +46,7 @@ final class Interface_ extends AbstractFactory implements ProjectFactoryStrategy
         ContextStack $context,
         object $object,
         StrategyContainer $strategies
-    ) : void {
+    ): void {
         $docBlock = $this->createDocBlock($object->getDocComment(), $context->getTypeContext());
         $parents  = [];
         foreach ($object->extends as $extend) {

--- a/src/phpDocumentor/Reflection/Php/Factory/Method.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Method.php
@@ -29,7 +29,7 @@ use Webmozart\Assert\Assert;
  */
 final class Method extends AbstractFactory implements ProjectFactoryStrategy
 {
-    public function matches(ContextStack $context, object $object) : bool
+    public function matches(ContextStack $context, object $object): bool
     {
         return $object instanceof ClassMethod;
     }
@@ -44,7 +44,7 @@ final class Method extends AbstractFactory implements ProjectFactoryStrategy
         ContextStack $context,
         object $object,
         StrategyContainer $strategies
-    ) : void {
+    ): void {
         $methodContainer = $context->peek();
         Assert::isInstanceOfAny(
             $methodContainer,
@@ -77,7 +77,7 @@ final class Method extends AbstractFactory implements ProjectFactoryStrategy
     /**
      * Converts the visibility of the method to a valid Visibility object.
      */
-    private function buildVisibility(ClassMethod $node) : Visibility
+    private function buildVisibility(ClassMethod $node): Visibility
     {
         if ($node->isPrivate()) {
             return new Visibility(Visibility::PRIVATE_);

--- a/src/phpDocumentor/Reflection/Php/Factory/Namespace_.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Namespace_.php
@@ -12,6 +12,7 @@ use phpDocumentor\Reflection\Php\StrategyContainer;
 use phpDocumentor\Reflection\Types\NamespaceNodeToContext;
 use PhpParser\Node\Stmt\Namespace_ as NamespaceNode;
 use Webmozart\Assert\Assert;
+
 use function get_class;
 use function gettype;
 use function is_object;

--- a/src/phpDocumentor/Reflection/Php/Factory/Namespace_.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Namespace_.php
@@ -19,7 +19,7 @@ use function sprintf;
 
 class Namespace_ implements ProjectFactoryStrategy
 {
-    public function matches(ContextStack $context, object $object) : bool
+    public function matches(ContextStack $context, object $object): bool
     {
         return $object instanceof NamespaceNode;
     }
@@ -27,7 +27,7 @@ class Namespace_ implements ProjectFactoryStrategy
     /**
      * @param NamespaceNode $object
      */
-    public function create(ContextStack $context, object $object, StrategyContainer $strategies) : void
+    public function create(ContextStack $context, object $object, StrategyContainer $strategies): void
     {
         if (!$this->matches($context, $object)) {
             throw new InvalidArgumentException(

--- a/src/phpDocumentor/Reflection/Php/Factory/Noop.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Noop.php
@@ -9,12 +9,12 @@ use phpDocumentor\Reflection\Php\StrategyContainer;
 
 class Noop implements ProjectFactoryStrategy
 {
-    public function matches(ContextStack $context, object $object) : bool
+    public function matches(ContextStack $context, object $object): bool
     {
         return true;
     }
 
-    public function create(ContextStack $context, object $object, StrategyContainer $strategies) : void
+    public function create(ContextStack $context, object $object, StrategyContainer $strategies): void
     {
     }
 }

--- a/src/phpDocumentor/Reflection/Php/Factory/Property.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Property.php
@@ -45,7 +45,7 @@ final class Property extends AbstractFactory implements ProjectFactoryStrategy
         parent::__construct($docBlockFactory);
     }
 
-    public function matches(ContextStack $context, object $object) : bool
+    public function matches(ContextStack $context, object $object): bool
     {
         return $object instanceof PropertyNode;
     }
@@ -63,7 +63,7 @@ final class Property extends AbstractFactory implements ProjectFactoryStrategy
         ContextStack $context,
         object $object,
         StrategyContainer $strategies
-    ) : void {
+    ): void {
         $propertyContainer = $context->peek();
         Assert::isInstanceOfAny(
             $propertyContainer,
@@ -97,7 +97,7 @@ final class Property extends AbstractFactory implements ProjectFactoryStrategy
     /**
      * Converts the visibility of the property to a valid Visibility object.
      */
-    private function buildVisibility(PropertyIterator $node) : Visibility
+    private function buildVisibility(PropertyIterator $node): Visibility
     {
         if ($node->isPrivate()) {
             return new Visibility(Visibility::PRIVATE_);

--- a/src/phpDocumentor/Reflection/Php/Factory/PropertyIterator.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/PropertyIterator.php
@@ -46,7 +46,7 @@ final class PropertyIterator implements Iterator
     /**
      * returns true when the current property is public.
      */
-    public function isPublic() : bool
+    public function isPublic(): bool
     {
         return $this->property->isPublic();
     }
@@ -54,7 +54,7 @@ final class PropertyIterator implements Iterator
     /**
      * returns true when the current property is protected.
      */
-    public function isProtected() : bool
+    public function isProtected(): bool
     {
         return $this->property->isProtected();
     }
@@ -62,7 +62,7 @@ final class PropertyIterator implements Iterator
     /**
      * returns true when the current property is private.
      */
-    public function isPrivate() : bool
+    public function isPrivate(): bool
     {
         return $this->property->isPrivate();
     }
@@ -70,7 +70,7 @@ final class PropertyIterator implements Iterator
     /**
      * returns true when the current property is static.
      */
-    public function isStatic() : bool
+    public function isStatic(): bool
     {
         return $this->property->isStatic();
     }
@@ -78,7 +78,7 @@ final class PropertyIterator implements Iterator
     /**
      * Gets line the node started in.
      */
-    public function getLine() : int
+    public function getLine(): int
     {
         return $this->property->getLine();
     }
@@ -98,7 +98,7 @@ final class PropertyIterator implements Iterator
      *
      * The doc comment has to be the last comment associated with the node.
      */
-    public function getDocComment() : ?Doc
+    public function getDocComment(): ?Doc
     {
         $docComment = $this->property->props[$this->index]->getDocComment();
         if ($docComment === null) {
@@ -111,7 +111,7 @@ final class PropertyIterator implements Iterator
     /**
      * returns the name of the current property.
      */
-    public function getName() : string
+    public function getName(): string
     {
         return (string) $this->property->props[$this->index]->name;
     }
@@ -129,7 +129,7 @@ final class PropertyIterator implements Iterator
     /**
      * Returns the fqsen of the current property.
      */
-    public function getFqsen() : Fqsen
+    public function getFqsen(): Fqsen
     {
         return $this->property->props[$this->index]->fqsen;
     }
@@ -137,7 +137,7 @@ final class PropertyIterator implements Iterator
     /**
      * @link http://php.net/manual/en/iterator.current.php
      */
-    public function current() : self
+    public function current(): self
     {
         return $this;
     }
@@ -145,7 +145,7 @@ final class PropertyIterator implements Iterator
     /**
      * @link http://php.net/manual/en/iterator.next.php
      */
-    public function next() : void
+    public function next(): void
     {
         ++$this->index;
     }
@@ -153,7 +153,7 @@ final class PropertyIterator implements Iterator
     /**
      * @link http://php.net/manual/en/iterator.key.php
      */
-    public function key() : ?int
+    public function key(): ?int
     {
         return $this->index;
     }
@@ -161,7 +161,7 @@ final class PropertyIterator implements Iterator
     /**
      * @link http://php.net/manual/en/iterator.valid.php
      */
-    public function valid() : bool
+    public function valid(): bool
     {
         return isset($this->property->props[$this->index]);
     }
@@ -169,7 +169,7 @@ final class PropertyIterator implements Iterator
     /**
      * @link http://php.net/manual/en/iterator.rewind.php
      */
-    public function rewind() : void
+    public function rewind(): void
     {
         $this->index = 0;
     }

--- a/src/phpDocumentor/Reflection/Php/Factory/TraitUse.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/TraitUse.php
@@ -14,7 +14,7 @@ use PhpParser\Node\Stmt\TraitUse as TraitUseNode;
 
 final class TraitUse implements ProjectFactoryStrategy
 {
-    public function matches(ContextStack $context, object $object) : bool
+    public function matches(ContextStack $context, object $object): bool
     {
         return $object instanceof TraitUseNode;
     }
@@ -23,7 +23,7 @@ final class TraitUse implements ProjectFactoryStrategy
      * @param ContextStack $context of the created object
      * @param TraitUseNode $object
      */
-    public function create(ContextStack $context, object $object, StrategyContainer $strategies) : void
+    public function create(ContextStack $context, object $object, StrategyContainer $strategies): void
     {
         if ($this->matches($context, $object) === false) {
             throw new InvalidArgumentException('Does not match expected node');

--- a/src/phpDocumentor/Reflection/Php/Factory/Trait_.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Trait_.php
@@ -23,7 +23,7 @@ use Webmozart\Assert\Assert;
 
 final class Trait_ extends AbstractFactory implements ProjectFactoryStrategy
 {
-    public function matches(ContextStack $context, object $object) : bool
+    public function matches(ContextStack $context, object $object): bool
     {
         return $object instanceof TraitNode;
     }
@@ -37,7 +37,7 @@ final class Trait_ extends AbstractFactory implements ProjectFactoryStrategy
      * @param ContextStack $context used to convert nested objects.
      * @param TraitNode $object
      */
-    protected function doCreate(ContextStack $context, object $object, StrategyContainer $strategies) : void
+    protected function doCreate(ContextStack $context, object $object, StrategyContainer $strategies): void
     {
         $trait = new TraitElement(
             $object->fqsen,

--- a/src/phpDocumentor/Reflection/Php/Factory/Type.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Type.php
@@ -20,6 +20,7 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\UnionType;
+
 use function implode;
 
 final class Type

--- a/src/phpDocumentor/Reflection/Php/Factory/Type.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Type.php
@@ -27,7 +27,7 @@ final class Type
     /**
      * @param Identifier|Name|NullableType|UnionType|null $type
      */
-    public function fromPhpParser($type, ?Context $context = null) : ?TypeElement
+    public function fromPhpParser($type, ?Context $context = null): ?TypeElement
     {
         if ($type === null) {
             return null;

--- a/src/phpDocumentor/Reflection/Php/File.php
+++ b/src/phpDocumentor/Reflection/Php/File.php
@@ -15,6 +15,7 @@ namespace phpDocumentor\Reflection\Php;
 
 use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\Fqsen;
+
 use function basename;
 
 /**

--- a/src/phpDocumentor/Reflection/Php/File.php
+++ b/src/phpDocumentor/Reflection/Php/File.php
@@ -75,7 +75,7 @@ final class File
     /**
      * Returns the hash of the contents for this file.
      */
-    public function getHash() : string
+    public function getHash(): string
     {
         return $this->hash;
     }
@@ -83,7 +83,7 @@ final class File
     /**
      * Retrieves the contents of this file.
      */
-    public function getSource() : string
+    public function getSource(): string
     {
         return $this->source;
     }
@@ -93,7 +93,7 @@ final class File
      *
      * @return Fqsen[]
      */
-    public function getNamespaces() : array
+    public function getNamespaces(): array
     {
         return $this->namespaces;
     }
@@ -101,7 +101,7 @@ final class File
     /**
      * Add namespace to file
      */
-    public function addNamespace(Fqsen $fqsen) : void
+    public function addNamespace(Fqsen $fqsen): void
     {
         $this->namespaces[(string) $fqsen] = $fqsen;
     }
@@ -111,12 +111,12 @@ final class File
      *
      * @return string[]
      */
-    public function getIncludes() : array
+    public function getIncludes(): array
     {
         return $this->includes;
     }
 
-    public function addInclude(string $include) : void
+    public function addInclude(string $include): void
     {
         $this->includes[$include] = $include;
     }
@@ -126,7 +126,7 @@ final class File
      *
      * @return Constant[]
      */
-    public function getConstants() : array
+    public function getConstants(): array
     {
         return $this->constants;
     }
@@ -134,7 +134,7 @@ final class File
     /**
      * Add constant to this file.
      */
-    public function addConstant(Constant $constant) : void
+    public function addConstant(Constant $constant): void
     {
         $this->constants[(string) $constant->getFqsen()] = $constant;
     }
@@ -144,7 +144,7 @@ final class File
      *
      * @return Function_[]
      */
-    public function getFunctions() : array
+    public function getFunctions(): array
     {
         return $this->functions;
     }
@@ -152,7 +152,7 @@ final class File
     /**
      * Add function to this file.
      */
-    public function addFunction(Function_ $function) : void
+    public function addFunction(Function_ $function): void
     {
         $this->functions[(string) $function->getFqsen()] = $function;
     }
@@ -162,7 +162,7 @@ final class File
      *
      * @return Class_[]
      */
-    public function getClasses() : array
+    public function getClasses(): array
     {
         return $this->classes;
     }
@@ -170,7 +170,7 @@ final class File
     /**
      * Add Class to this file.
      */
-    public function addClass(Class_ $class) : void
+    public function addClass(Class_ $class): void
     {
         $this->classes[(string) $class->getFqsen()] = $class;
     }
@@ -180,7 +180,7 @@ final class File
      *
      * @return Interface_[]
      */
-    public function getInterfaces() : array
+    public function getInterfaces(): array
     {
         return $this->interfaces;
     }
@@ -188,7 +188,7 @@ final class File
     /**
      * Add interface to this file.
      */
-    public function addInterface(Interface_ $interface) : void
+    public function addInterface(Interface_ $interface): void
     {
         $this->interfaces[(string) $interface->getFqsen()] = $interface;
     }
@@ -198,7 +198,7 @@ final class File
      *
      * @return Trait_[]
      */
-    public function getTraits() : array
+    public function getTraits(): array
     {
         return $this->traits;
     }
@@ -206,7 +206,7 @@ final class File
     /**
      * Add trait to this file.
      */
-    public function addTrait(Trait_ $trait) : void
+    public function addTrait(Trait_ $trait): void
     {
         $this->traits[(string) $trait->getFqsen()] = $trait;
     }
@@ -214,7 +214,7 @@ final class File
     /**
      * Returns the file path relative to the project's root.
      */
-    public function getPath() : string
+    public function getPath(): string
     {
         return $this->path;
     }
@@ -222,7 +222,7 @@ final class File
     /**
      * Returns the DocBlock of the element if available
      */
-    public function getDocBlock() : ?DocBlock
+    public function getDocBlock(): ?DocBlock
     {
         return $this->docBlock;
     }
@@ -230,7 +230,7 @@ final class File
     /**
      * Returns the full name of this file
      */
-    public function getName() : string
+    public function getName(): string
     {
         return $this->name;
     }

--- a/src/phpDocumentor/Reflection/Php/Function_.php
+++ b/src/phpDocumentor/Reflection/Php/Function_.php
@@ -70,7 +70,7 @@ final class Function_ implements Element
      *
      * @return Argument[]
      */
-    public function getArguments() : array
+    public function getArguments(): array
     {
         return $this->arguments;
     }
@@ -78,7 +78,7 @@ final class Function_ implements Element
     /**
      * Add an argument to the function.
      */
-    public function addArgument(Argument $argument) : void
+    public function addArgument(Argument $argument): void
     {
         $this->arguments[] = $argument;
     }
@@ -86,7 +86,7 @@ final class Function_ implements Element
     /**
      * Returns the Fqsen of the element.
      */
-    public function getFqsen() : Fqsen
+    public function getFqsen(): Fqsen
     {
         return $this->fqsen;
     }
@@ -94,7 +94,7 @@ final class Function_ implements Element
     /**
      * Returns the name of the element.
      */
-    public function getName() : string
+    public function getName(): string
     {
         return $this->fqsen->getName();
     }
@@ -102,17 +102,17 @@ final class Function_ implements Element
     /**
      * Returns the DocBlock of the element if available
      */
-    public function getDocBlock() : ?DocBlock
+    public function getDocBlock(): ?DocBlock
     {
         return $this->docBlock;
     }
 
-    public function getLocation() : Location
+    public function getLocation(): Location
     {
         return $this->location;
     }
 
-    public function getReturnType() : Type
+    public function getReturnType(): Type
     {
         return $this->returnType;
     }

--- a/src/phpDocumentor/Reflection/Php/Interface_.php
+++ b/src/phpDocumentor/Reflection/Php/Interface_.php
@@ -66,7 +66,7 @@ final class Interface_ implements Element
      *
      * @return Constant[]
      */
-    public function getConstants() : array
+    public function getConstants(): array
     {
         return $this->constants;
     }
@@ -74,7 +74,7 @@ final class Interface_ implements Element
     /**
      * Add constant to this interface.
      */
-    public function addConstant(Constant $constant) : void
+    public function addConstant(Constant $constant): void
     {
         $this->constants[(string) $constant->getFqsen()] = $constant;
     }
@@ -84,7 +84,7 @@ final class Interface_ implements Element
      *
      * @return Method[]
      */
-    public function getMethods() : array
+    public function getMethods(): array
     {
         return $this->methods;
     }
@@ -92,7 +92,7 @@ final class Interface_ implements Element
     /**
      * Add method to this interface.
      */
-    public function addMethod(Method $method) : void
+    public function addMethod(Method $method): void
     {
         $this->methods[(string) $method->getFqsen()] = $method;
     }
@@ -100,7 +100,7 @@ final class Interface_ implements Element
     /**
      * Returns the Fqsen of the element.
      */
-    public function getFqsen() : Fqsen
+    public function getFqsen(): Fqsen
     {
         return $this->fqsen;
     }
@@ -108,7 +108,7 @@ final class Interface_ implements Element
     /**
      * Returns the name of the element.
      */
-    public function getName() : string
+    public function getName(): string
     {
         return $this->fqsen->getName();
     }
@@ -116,7 +116,7 @@ final class Interface_ implements Element
     /**
      * Returns the DocBlock of this interface if available.
      */
-    public function getDocBlock() : ?DocBlock
+    public function getDocBlock(): ?DocBlock
     {
         return $this->docBlock;
     }
@@ -126,12 +126,12 @@ final class Interface_ implements Element
      *
      * @return Fqsen[]
      */
-    public function getParents() : array
+    public function getParents(): array
     {
         return $this->parents;
     }
 
-    public function getLocation() : Location
+    public function getLocation(): Location
     {
         return $this->location;
     }

--- a/src/phpDocumentor/Reflection/Php/Method.php
+++ b/src/phpDocumentor/Reflection/Php/Method.php
@@ -93,7 +93,7 @@ final class Method implements Element
     /**
      * Returns true when this method is abstract. Otherwise returns false.
      */
-    public function isAbstract() : bool
+    public function isAbstract(): bool
     {
         return $this->abstract;
     }
@@ -101,7 +101,7 @@ final class Method implements Element
     /**
      * Returns true when this method is final. Otherwise returns false.
      */
-    public function isFinal() : bool
+    public function isFinal(): bool
     {
         return $this->final;
     }
@@ -109,7 +109,7 @@ final class Method implements Element
     /**
      * Returns true when this method is static. Otherwise returns false.
      */
-    public function isStatic() : bool
+    public function isStatic(): bool
     {
         return $this->static;
     }
@@ -117,7 +117,7 @@ final class Method implements Element
     /**
      * Returns the Visibility of this method.
      */
-    public function getVisibility() : ?Visibility
+    public function getVisibility(): ?Visibility
     {
         return $this->visibility;
     }
@@ -127,7 +127,7 @@ final class Method implements Element
      *
      * @return Argument[]
      */
-    public function getArguments() : array
+    public function getArguments(): array
     {
         return $this->arguments;
     }
@@ -135,7 +135,7 @@ final class Method implements Element
     /**
      * Add new argument to this method.
      */
-    public function addArgument(Argument $argument) : void
+    public function addArgument(Argument $argument): void
     {
         $this->arguments[] = $argument;
     }
@@ -143,7 +143,7 @@ final class Method implements Element
     /**
      * Returns the Fqsen of the element.
      */
-    public function getFqsen() : Fqsen
+    public function getFqsen(): Fqsen
     {
         return $this->fqsen;
     }
@@ -151,7 +151,7 @@ final class Method implements Element
     /**
      * Returns the name of the element.
      */
-    public function getName() : string
+    public function getName(): string
     {
         return $this->fqsen->getName();
     }
@@ -161,12 +161,12 @@ final class Method implements Element
      *
      * @returns null|DocBlock
      */
-    public function getDocBlock() : ?DocBlock
+    public function getDocBlock(): ?DocBlock
     {
         return $this->docBlock;
     }
 
-    public function getLocation() : Location
+    public function getLocation(): Location
     {
         return $this->location;
     }
@@ -178,7 +178,7 @@ final class Method implements Element
      * return type defined this method will return Mixed_ by default. The return value of this
      * method is not affected by the return tag in your docblock.
      */
-    public function getReturnType() : Type
+    public function getReturnType(): Type
     {
         return $this->returnType;
     }

--- a/src/phpDocumentor/Reflection/Php/NodesFactory.php
+++ b/src/phpDocumentor/Reflection/Php/NodesFactory.php
@@ -60,7 +60,7 @@ class NodesFactory
      *
      * @return static
      */
-    public static function createInstance(int $kind = ParserFactory::PREFER_PHP7) : self
+    public static function createInstance(int $kind = ParserFactory::PREFER_PHP7): self
     {
         $parser = (new ParserFactory())->create($kind);
         $traverser = new NodeTraverser();
@@ -77,7 +77,7 @@ class NodesFactory
      *
      * @return Node[]
      */
-    public function create(string $code) : array
+    public function create(string $code): array
     {
         return $this->traverser->traverse($this->parser->parse($code));
     }

--- a/src/phpDocumentor/Reflection/Php/Project.php
+++ b/src/phpDocumentor/Reflection/Php/Project.php
@@ -53,7 +53,7 @@ final class Project implements ProjectInterface
     /**
      * Returns the name of this project.
      */
-    public function getName() : string
+    public function getName(): string
     {
         return $this->name;
     }
@@ -63,7 +63,7 @@ final class Project implements ProjectInterface
      *
      * @return File[]
      */
-    public function getFiles() : array
+    public function getFiles(): array
     {
         return $this->files;
     }
@@ -71,7 +71,7 @@ final class Project implements ProjectInterface
     /**
      * Add a file to this project.
      */
-    public function addFile(File $file) : void
+    public function addFile(File $file): void
     {
         $this->files[$file->getPath()] = $file;
     }
@@ -81,7 +81,7 @@ final class Project implements ProjectInterface
      *
      * @return Namespace_[]
      */
-    public function getNamespaces() : array
+    public function getNamespaces(): array
     {
         return $this->namespaces;
     }
@@ -89,7 +89,7 @@ final class Project implements ProjectInterface
     /**
      * Add a namespace to the project.
      */
-    public function addNamespace(Namespace_ $namespace) : void
+    public function addNamespace(Namespace_ $namespace): void
     {
         $this->namespaces[(string) $namespace->getFqsen()] = $namespace;
     }
@@ -97,7 +97,7 @@ final class Project implements ProjectInterface
     /**
      * Returns the root (global) namespace.
      */
-    public function getRootNamespace() : ?Namespace_
+    public function getRootNamespace(): ?Namespace_
     {
         return $this->rootNamespace;
     }

--- a/src/phpDocumentor/Reflection/Php/ProjectFactory.php
+++ b/src/phpDocumentor/Reflection/Php/ProjectFactory.php
@@ -47,7 +47,7 @@ final class ProjectFactory implements ProjectFactoryInterface
     /**
      * Creates a new instance of this factory. With all default strategies.
      */
-    public static function createInstance() : self
+    public static function createInstance(): self
     {
         $docblockFactory = DocBlockFactory::createInstance();
 
@@ -90,7 +90,7 @@ final class ProjectFactory implements ProjectFactoryInterface
      *
      * @throws Exception When no matching strategy was found.
      */
-    public function create(string $name, array $files) : ProjectInterface
+    public function create(string $name, array $files): ProjectInterface
     {
         $contextStack = new ContextStack(new Project($name), null);
 
@@ -108,7 +108,7 @@ final class ProjectFactory implements ProjectFactoryInterface
     /**
      * Builds the namespace tree with all elements in the project.
      */
-    private function buildNamespaces(Project $project) : void
+    private function buildNamespaces(Project $project): void
     {
         foreach ($project->getFiles() as $file) {
             foreach ($file->getNamespaces() as $namespaceFqsen) {
@@ -121,7 +121,7 @@ final class ProjectFactory implements ProjectFactoryInterface
     /**
      * Gets Namespace from the project if it exists, otherwise returns a new namepace
      */
-    private function getNamespaceByName(Project $project, string $name) : Namespace_
+    private function getNamespaceByName(Project $project, string $name): Namespace_
     {
         $existingNamespaces = $project->getNamespaces();
 
@@ -138,7 +138,7 @@ final class ProjectFactory implements ProjectFactoryInterface
     /**
      * Adds all elements belonging to the namespace to the namespace.
      */
-    private function buildNamespace(File $file, Namespace_ $namespace) : void
+    private function buildNamespace(File $file, Namespace_ $namespace): void
     {
         foreach ($file->getClasses() as $class) {
             if ($namespace->getFqsen() . '\\' . $class->getName() !== (string) $class->getFqsen()) {

--- a/src/phpDocumentor/Reflection/Php/ProjectFactory.php
+++ b/src/phpDocumentor/Reflection/Php/ProjectFactory.php
@@ -23,7 +23,9 @@ use phpDocumentor\Reflection\Php\Factory\TraitUse;
 use phpDocumentor\Reflection\Project as ProjectInterface;
 use phpDocumentor\Reflection\ProjectFactory as ProjectFactoryInterface;
 use PhpParser\PrettyPrinter\Standard as PrettyPrinter;
+
 use function is_array;
+
 use const PHP_INT_MAX;
 
 /**

--- a/src/phpDocumentor/Reflection/Php/ProjectFactory.php
+++ b/src/phpDocumentor/Reflection/Php/ProjectFactory.php
@@ -167,8 +167,10 @@ final class ProjectFactory implements ProjectFactoryInterface
         }
 
         foreach ($file->getConstants() as $constant) {
-            if ($namespace->getFqsen() . '::' . $constant->getName() !== (string) $constant->getFqsen() &&
-                $namespace->getFqsen() . '\\' . $constant->getName() !== (string) $constant->getFqsen()) {
+            if (
+                $namespace->getFqsen() . '::' . $constant->getName() !== (string) $constant->getFqsen() &&
+                $namespace->getFqsen() . '\\' . $constant->getName() !== (string) $constant->getFqsen()
+            ) {
                 continue;
             }
 

--- a/src/phpDocumentor/Reflection/Php/ProjectFactoryStrategies.php
+++ b/src/phpDocumentor/Reflection/Php/ProjectFactoryStrategies.php
@@ -48,7 +48,7 @@ final class ProjectFactoryStrategies implements StrategyContainer
      *
      * @throws OutOfBoundsException When no matching strategy was found.
      */
-    public function findMatching(ContextStack $context, $object) : ProjectFactoryStrategy
+    public function findMatching(ContextStack $context, $object): ProjectFactoryStrategy
     {
         foreach (clone $this->strategies as $strategy) {
             if ($strategy->matches($context, $object)) {
@@ -67,7 +67,7 @@ final class ProjectFactoryStrategies implements StrategyContainer
     /**
      * Add a strategy to this container.
      */
-    public function addStrategy(ProjectFactoryStrategy $strategy, int $priority = self::DEFAULT_PRIORITY) : void
+    public function addStrategy(ProjectFactoryStrategy $strategy, int $priority = self::DEFAULT_PRIORITY): void
     {
         $this->strategies->insert($strategy, $priority);
     }

--- a/src/phpDocumentor/Reflection/Php/ProjectFactoryStrategies.php
+++ b/src/phpDocumentor/Reflection/Php/ProjectFactoryStrategies.php
@@ -16,6 +16,7 @@ namespace phpDocumentor\Reflection\Php;
 use OutOfBoundsException;
 use phpDocumentor\Reflection\Php\Factory\ContextStack;
 use SplPriorityQueue;
+
 use function get_class;
 use function is_object;
 use function print_r;

--- a/src/phpDocumentor/Reflection/Php/ProjectFactoryStrategy.php
+++ b/src/phpDocumentor/Reflection/Php/ProjectFactoryStrategy.php
@@ -23,7 +23,7 @@ interface ProjectFactoryStrategy
     /**
      * Returns true when the strategy is able to handle the object.
      */
-    public function matches(ContextStack $context, object $object) : bool;
+    public function matches(ContextStack $context, object $object): bool;
 
     /**
      * Creates an Element out of the given object.
@@ -37,5 +37,5 @@ interface ProjectFactoryStrategy
      * @param object $object object to convert to an Element
      * @param StrategyContainer $strategies used to convert nested objects.
      */
-    public function create(ContextStack $context, object $object, StrategyContainer $strategies) : void;
+    public function create(ContextStack $context, object $object, StrategyContainer $strategies): void;
 }

--- a/src/phpDocumentor/Reflection/Php/Property.php
+++ b/src/phpDocumentor/Reflection/Php/Property.php
@@ -72,7 +72,7 @@ final class Property implements Element
     /**
      * returns the default value of this property.
      */
-    public function getDefault() : ?string
+    public function getDefault(): ?string
     {
         return $this->default;
     }
@@ -80,7 +80,7 @@ final class Property implements Element
     /**
      * Returns true when this method is static. Otherwise returns false.
      */
-    public function isStatic() : bool
+    public function isStatic(): bool
     {
         return $this->static;
     }
@@ -90,7 +90,7 @@ final class Property implements Element
      *
      * @return string[]
      */
-    public function getTypes() : array
+    public function getTypes(): array
     {
         return $this->types;
     }
@@ -98,7 +98,7 @@ final class Property implements Element
     /**
      * Add a type to this property
      */
-    public function addType(string $type) : void
+    public function addType(string $type): void
     {
         $this->types[] = $type;
     }
@@ -106,7 +106,7 @@ final class Property implements Element
     /**
      * Return visibility of the property.
      */
-    public function getVisibility() : ?Visibility
+    public function getVisibility(): ?Visibility
     {
         return $this->visibility;
     }
@@ -114,7 +114,7 @@ final class Property implements Element
     /**
      * Returns the Fqsen of the element.
      */
-    public function getFqsen() : Fqsen
+    public function getFqsen(): Fqsen
     {
         return $this->fqsen;
     }
@@ -122,7 +122,7 @@ final class Property implements Element
     /**
      * Returns the name of the element.
      */
-    public function getName() : string
+    public function getName(): string
     {
         return $this->fqsen->getName();
     }
@@ -130,17 +130,17 @@ final class Property implements Element
     /**
      * Returns the DocBlock of this property.
      */
-    public function getDocBlock() : ?DocBlock
+    public function getDocBlock(): ?DocBlock
     {
         return $this->docBlock;
     }
 
-    public function getLocation() : Location
+    public function getLocation(): Location
     {
         return $this->location;
     }
 
-    public function getType() : ?Type
+    public function getType(): ?Type
     {
         return $this->type;
     }

--- a/src/phpDocumentor/Reflection/Php/StrategyContainer.php
+++ b/src/phpDocumentor/Reflection/Php/StrategyContainer.php
@@ -28,5 +28,5 @@ interface StrategyContainer
      *
      * @throws Exception When no matching strategy was found.
      */
-    public function findMatching(ContextStack $context, $object) : ProjectFactoryStrategy;
+    public function findMatching(ContextStack $context, $object): ProjectFactoryStrategy;
 }

--- a/src/phpDocumentor/Reflection/Php/Trait_.php
+++ b/src/phpDocumentor/Reflection/Php/Trait_.php
@@ -60,7 +60,7 @@ final class Trait_ implements Element
      *
      * @return Method[]
      */
-    public function getMethods() : array
+    public function getMethods(): array
     {
         return $this->methods;
     }
@@ -68,7 +68,7 @@ final class Trait_ implements Element
     /**
      * Add a method to this Trait
      */
-    public function addMethod(Method $method) : void
+    public function addMethod(Method $method): void
     {
         $this->methods[(string) $method->getFqsen()] = $method;
     }
@@ -78,7 +78,7 @@ final class Trait_ implements Element
      *
      * @return Property[]
      */
-    public function getProperties() : array
+    public function getProperties(): array
     {
         return $this->properties;
     }
@@ -86,7 +86,7 @@ final class Trait_ implements Element
     /**
      * Add a property to this Trait.
      */
-    public function addProperty(Property $property) : void
+    public function addProperty(Property $property): void
     {
         $this->properties[(string) $property->getFqsen()] = $property;
     }
@@ -94,7 +94,7 @@ final class Trait_ implements Element
     /**
      * Returns the Fqsen of the element.
      */
-    public function getFqsen() : Fqsen
+    public function getFqsen(): Fqsen
     {
         return $this->fqsen;
     }
@@ -102,12 +102,12 @@ final class Trait_ implements Element
     /**
      * Returns the name of the element.
      */
-    public function getName() : string
+    public function getName(): string
     {
         return $this->fqsen->getName();
     }
 
-    public function getDocBlock() : ?DocBlock
+    public function getDocBlock(): ?DocBlock
     {
         return $this->docBlock;
     }
@@ -117,7 +117,7 @@ final class Trait_ implements Element
      *
      * @return Fqsen[]
      */
-    public function getUsedTraits() : array
+    public function getUsedTraits(): array
     {
         return $this->usedTraits;
     }
@@ -125,12 +125,12 @@ final class Trait_ implements Element
     /**
      * Add reference to trait used by this trait.
      */
-    public function addUsedTrait(Fqsen $fqsen) : void
+    public function addUsedTrait(Fqsen $fqsen): void
     {
         $this->usedTraits[(string) $fqsen] = $fqsen;
     }
 
-    public function getLocation() : Location
+    public function getLocation(): Location
     {
         return $this->location;
     }

--- a/src/phpDocumentor/Reflection/Php/Visibility.php
+++ b/src/phpDocumentor/Reflection/Php/Visibility.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Reflection\Php;
 
 use InvalidArgumentException;
+
 use function sprintf;
 use function strtolower;
 

--- a/src/phpDocumentor/Reflection/Php/Visibility.php
+++ b/src/phpDocumentor/Reflection/Php/Visibility.php
@@ -61,7 +61,7 @@ final class Visibility
     /**
      * Will return a string representation of visibility.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return $this->visibility;
     }

--- a/src/phpDocumentor/Reflection/Types/NamespaceNodeToContext.php
+++ b/src/phpDocumentor/Reflection/Types/NamespaceNodeToContext.php
@@ -16,7 +16,7 @@ use function in_array;
 
 class NamespaceNodeToContext
 {
-    public function __invoke(?Namespace_ $namespace) : Context
+    public function __invoke(?Namespace_ $namespace): Context
     {
         if (!$namespace) {
             return new Context('');
@@ -31,11 +31,11 @@ class NamespaceNodeToContext
     /**
      * @return string[] indexed by alias
      */
-    private function aliasesToFullyQualifiedNames(Namespace_ $namespace) : array
+    private function aliasesToFullyQualifiedNames(Namespace_ $namespace): array
     {
         // flatten(flatten(map(stuff)))
-        return array_merge([], ...array_merge([], ...array_map(static function ($use) : array {
-            return array_map(static function (UseUse $useUse) use ($use) : array {
+        return array_merge([], ...array_merge([], ...array_map(static function ($use): array {
+            return array_map(static function (UseUse $useUse) use ($use): array {
                 if ($use instanceof GroupUse) {
                     return [
                         (string) $useUse->getAlias() => $use->prefix->toString() . '\\' . $useUse->name->toString(),
@@ -50,11 +50,11 @@ class NamespaceNodeToContext
     /**
      * @return Use_[]|GroupUse[]
      */
-    private function classAlikeUses(Namespace_ $namespace) : array
+    private function classAlikeUses(Namespace_ $namespace): array
     {
         return array_filter(
             $namespace->stmts ?? [],
-            static function (Node $node) : bool {
+            static function (Node $node): bool {
                 return (
                         $node instanceof Use_
                         || $node instanceof GroupUse

--- a/src/phpDocumentor/Reflection/Types/NamespaceNodeToContext.php
+++ b/src/phpDocumentor/Reflection/Types/NamespaceNodeToContext.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Stmt\GroupUse;
 use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Use_;
 use PhpParser\Node\Stmt\UseUse;
+
 use function array_filter;
 use function array_map;
 use function array_merge;

--- a/tests/unit/phpDocumentor/Reflection/File/LocalFileTest.php
+++ b/tests/unit/phpDocumentor/Reflection/File/LocalFileTest.php
@@ -25,7 +25,7 @@ class LocalFileTest extends TestCase
     /**
      * @covers ::getContents
      */
-    public function testGetContents() : void
+    public function testGetContents(): void
     {
         $file = new LocalFile(__FILE__);
         $this->assertStringEqualsFile(__FILE__, $file->getContents());
@@ -34,7 +34,7 @@ class LocalFileTest extends TestCase
     /**
      * @covers ::md5
      */
-    public function testMd5() : void
+    public function testMd5(): void
     {
         $file = new LocalFile(__FILE__);
         $this->assertEquals(md5_file(__FILE__), $file->md5());
@@ -43,7 +43,7 @@ class LocalFileTest extends TestCase
     /**
      * @covers ::__construct
      */
-    public function testNotExistingFileThrowsException() : void
+    public function testNotExistingFileThrowsException(): void
     {
         $this->expectException('InvalidArgumentException');
         new LocalFile('aa');
@@ -52,7 +52,7 @@ class LocalFileTest extends TestCase
     /**
      * @covers ::path
      */
-    public function testPath() : void
+    public function testPath(): void
     {
         $file = new LocalFile(__FILE__);
         $this->assertEquals(__FILE__, $file->path());

--- a/tests/unit/phpDocumentor/Reflection/File/LocalFileTest.php
+++ b/tests/unit/phpDocumentor/Reflection/File/LocalFileTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Reflection\File;
 
 use PHPUnit\Framework\TestCase;
+
 use function md5_file;
 
 /**

--- a/tests/unit/phpDocumentor/Reflection/Middleware/ChainFactoryTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Middleware/ChainFactoryTest.php
@@ -69,7 +69,7 @@ final class ChainFactoryTest extends TestCase
 
     private function givenAMiddleware(string $exampleValue): Middleware
     {
-        return new class($exampleValue) implements Middleware {
+        return new class ($exampleValue) implements Middleware {
             /** @var string */
             private $exampleAddedValue;
 

--- a/tests/unit/phpDocumentor/Reflection/Middleware/ChainFactoryTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Middleware/ChainFactoryTest.php
@@ -26,7 +26,7 @@ final class ChainFactoryTest extends TestCase
     /**
      * @covers ::createExecutionChain
      */
-    public function testItCreatesAChainOfCallablesThatWillInvokeAllMiddlewares() : void
+    public function testItCreatesAChainOfCallablesThatWillInvokeAllMiddlewares(): void
     {
         $exampleCommand = new class implements Command {
         };
@@ -51,7 +51,7 @@ final class ChainFactoryTest extends TestCase
     /**
      * @covers ::createExecutionChain
      */
-    public function testItThrowsAnExceptionIfAnythingOtherThanAMiddlewareIsPassed() : void
+    public function testItThrowsAnExceptionIfAnythingOtherThanAMiddlewareIsPassed(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
@@ -67,7 +67,7 @@ final class ChainFactoryTest extends TestCase
         );
     }
 
-    private function givenAMiddleware(string $exampleValue) : Middleware
+    private function givenAMiddleware(string $exampleValue): Middleware
     {
         return new class($exampleValue) implements Middleware {
             /** @var string */
@@ -78,7 +78,7 @@ final class ChainFactoryTest extends TestCase
                 $this->exampleAddedValue = $exampleAddedValue;
             }
 
-            public function execute(Command $command, callable $next) : object
+            public function execute(Command $command, callable $next): object
             {
                 $result = $next($command);
                 $result->counter .= $this->exampleAddedValue;

--- a/tests/unit/phpDocumentor/Reflection/NodeVisitor/ElementNameResolverTest.php
+++ b/tests/unit/phpDocumentor/Reflection/NodeVisitor/ElementNameResolverTest.php
@@ -37,7 +37,7 @@ class ElementNameResolverTest extends TestCase
     /** @var ElementNameResolver */
     private $fixture;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->fixture = new ElementNameResolver();
         $this->fixture->beforeTraverse([]);
@@ -46,7 +46,7 @@ class ElementNameResolverTest extends TestCase
     /**
      * @covers ::enterNode
      */
-    public function testFunctionWithoutNamespace() : void
+    public function testFunctionWithoutNamespace(): void
     {
         $function = new Function_('myFunction');
         $this->fixture->enterNode($function);
@@ -57,7 +57,7 @@ class ElementNameResolverTest extends TestCase
     /**
      * @covers ::enterNode
      */
-    public function testWithClass() : void
+    public function testWithClass(): void
     {
         $class = new Class_('myClass');
         $this->fixture->enterNode($class);
@@ -68,7 +68,7 @@ class ElementNameResolverTest extends TestCase
     /**
      * @covers ::enterNode
      */
-    public function testWithClassMethod() : void
+    public function testWithClassMethod(): void
     {
         $class = new Class_('myClass');
         $this->fixture->enterNode($class);
@@ -82,7 +82,7 @@ class ElementNameResolverTest extends TestCase
     /**
      * @covers ::enterNode
      */
-    public function testWithClassProperty() : void
+    public function testWithClassProperty(): void
     {
         $class = new Class_('myClass');
         $this->fixture->enterNode($class);
@@ -99,7 +99,7 @@ class ElementNameResolverTest extends TestCase
      *
      * @covers ::enterNode
      */
-    public function testDoesNotEnterAnonymousClass() : void
+    public function testDoesNotEnterAnonymousClass(): void
     {
         $class = new Class_(null);
         $this->assertEquals(
@@ -114,7 +114,7 @@ class ElementNameResolverTest extends TestCase
      * @covers ::enterNode
      * @covers ::leaveNode
      */
-    public function testAnonymousClassDoesNotPopParts() : void
+    public function testAnonymousClassDoesNotPopParts(): void
     {
         $anonymousClass = new Class_(null);
 
@@ -135,7 +135,7 @@ class ElementNameResolverTest extends TestCase
     /**
      * @covers ::enterNode
      */
-    public function testClassConstant() : void
+    public function testClassConstant(): void
     {
         $const      = new Const_('MY_CLASS', new String_('value'));
         $classConst = new ClassConst([$const]);
@@ -151,7 +151,7 @@ class ElementNameResolverTest extends TestCase
     /**
      * @covers ::enterNode
      */
-    public function testNamespacedConstant() : void
+    public function testNamespacedConstant(): void
     {
         $const     = new Const_('MY_CLASS', new String_('value'));
         $namespace = new Namespace_(new Name('name'));
@@ -165,7 +165,7 @@ class ElementNameResolverTest extends TestCase
     /**
      * @covers ::enterNode
      */
-    public function testNoNameNamespace() : void
+    public function testNoNameNamespace(): void
     {
         $const     = new Const_('MY_CLASS', new String_('value'));
         $namespace = new Namespace_(null);

--- a/tests/unit/phpDocumentor/Reflection/Php/ArgumentTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/ArgumentTest.php
@@ -30,7 +30,7 @@ final class ArgumentTest extends TestCase
     /**
      * @covers ::getType
      */
-    public function testGetTypes() : void
+    public function testGetTypes(): void
     {
         $argument = new Argument('myArgument', null, 'myDefaultValue', true, true);
         $this->assertInstanceOf(Mixed_::class, $argument->getType());
@@ -48,7 +48,7 @@ final class ArgumentTest extends TestCase
     /**
      * @covers ::getName
      */
-    public function testGetName() : void
+    public function testGetName(): void
     {
         $argument = new Argument('myArgument', null, 'myDefault', true, true);
         $this->assertEquals('myArgument', $argument->getName());
@@ -57,7 +57,7 @@ final class ArgumentTest extends TestCase
     /**
      * @covers ::getDefault
      */
-    public function testGetDefault() : void
+    public function testGetDefault(): void
     {
         $argument = new Argument('myArgument', null, 'myDefaultValue', true, true);
         $this->assertEquals('myDefaultValue', $argument->getDefault());
@@ -69,7 +69,7 @@ final class ArgumentTest extends TestCase
     /**
      * @covers ::isByReference
      */
-    public function testGetWhetherArgumentIsPassedByReference() : void
+    public function testGetWhetherArgumentIsPassedByReference(): void
     {
         $argument = new Argument('myArgument', null, 'myDefaultValue', true, true);
         $this->assertTrue($argument->isByReference());
@@ -81,7 +81,7 @@ final class ArgumentTest extends TestCase
     /**
      * @covers ::isVariadic
      */
-    public function testGetWhetherArgumentisVariadic() : void
+    public function testGetWhetherArgumentisVariadic(): void
     {
         $argument = new Argument('myArgument', null, 'myDefaultValue', true, true);
         $this->assertTrue($argument->isVariadic());

--- a/tests/unit/phpDocumentor/Reflection/Php/Class_Test.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Class_Test.php
@@ -46,7 +46,7 @@ final class Class_Test extends TestCase
     /**
      * Creates a new (emoty) fixture object.
      */
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->parent = new Fqsen('\MyParentClass');
         $this->fqsen = new Fqsen('\MyClass');
@@ -58,7 +58,7 @@ final class Class_Test extends TestCase
     /**
      * @covers ::getName
      */
-    public function testGettingName() : void
+    public function testGettingName(): void
     {
         $this->assertSame($this->fqsen->getName(), $this->fixture->getName());
     }
@@ -66,7 +66,7 @@ final class Class_Test extends TestCase
     /**
      * @covers ::getFqsen
      */
-    public function testGettingFqsen() : void
+    public function testGettingFqsen(): void
     {
         $this->assertSame($this->fqsen, $this->fixture->getFqsen());
     }
@@ -74,7 +74,7 @@ final class Class_Test extends TestCase
     /**
      * @covers ::getDocBlock
      */
-    public function testGettingDocBlock() : void
+    public function testGettingDocBlock(): void
     {
         $this->assertSame($this->docBlock, $this->fixture->getDocBlock());
     }
@@ -82,7 +82,7 @@ final class Class_Test extends TestCase
     /**
      * @covers ::getParent
      */
-    public function testGettingParent() : void
+    public function testGettingParent(): void
     {
         $class = new Class_($this->fqsen, $this->docBlock);
         $this->assertNull($class->getParent());
@@ -95,7 +95,7 @@ final class Class_Test extends TestCase
      * @covers ::getInterfaces
      * @covers ::AddInterface
      */
-    public function testAddAndGettingInterfaces() : void
+    public function testAddAndGettingInterfaces(): void
     {
         $this->assertEmpty($this->fixture->getInterfaces());
 
@@ -110,7 +110,7 @@ final class Class_Test extends TestCase
      * @covers ::getConstants
      * @covers ::addConstant
      */
-    public function testAddAndGettingConstants() : void
+    public function testAddAndGettingConstants(): void
     {
         $this->assertEmpty($this->fixture->getConstants());
 
@@ -125,7 +125,7 @@ final class Class_Test extends TestCase
      * @covers ::addProperty
      * @covers ::getProperties
      */
-    public function testAddAndGettingProperties() : void
+    public function testAddAndGettingProperties(): void
     {
         $this->assertEmpty($this->fixture->getProperties());
 
@@ -140,7 +140,7 @@ final class Class_Test extends TestCase
      * @covers ::addMethod
      * @covers ::getMethods
      */
-    public function testAddAndGettingMethods() : void
+    public function testAddAndGettingMethods(): void
     {
         $this->assertEmpty($this->fixture->getMethods());
 
@@ -155,7 +155,7 @@ final class Class_Test extends TestCase
      * @covers ::getUsedTraits
      * @covers ::AddUsedTrait
      */
-    public function testAddAndGettingUsedTrait() : void
+    public function testAddAndGettingUsedTrait(): void
     {
         $this->assertEmpty($this->fixture->getUsedTraits());
 
@@ -169,7 +169,7 @@ final class Class_Test extends TestCase
     /**
      * @covers ::isAbstract
      */
-    public function testGettingWhetherClassIsAbstract() : void
+    public function testGettingWhetherClassIsAbstract(): void
     {
         $class = new Class_($this->fqsen, $this->docBlock);
         $this->assertFalse($class->isAbstract());
@@ -181,7 +181,7 @@ final class Class_Test extends TestCase
     /**
      * @covers ::isFinal
      */
-    public function testGettingWhetherClassIsFinal() : void
+    public function testGettingWhetherClassIsFinal(): void
     {
         $class = new Class_($this->fqsen, $this->docBlock);
         $this->assertFalse($class->isFinal());
@@ -193,7 +193,7 @@ final class Class_Test extends TestCase
     /**
      * @covers ::getLocation
      */
-    public function testLineNumberIsMinusOneWhenNoneIsProvided() : void
+    public function testLineNumberIsMinusOneWhenNoneIsProvided(): void
     {
         $this->assertSame(-1, $this->fixture->getLocation()->getLineNumber());
         $this->assertSame(0, $this->fixture->getLocation()->getColumnNumber());
@@ -204,7 +204,7 @@ final class Class_Test extends TestCase
      *
      * @covers ::getLocation
      */
-    public function testLineAndColumnNumberIsReturnedWhenALocationIsProvided() : void
+    public function testLineAndColumnNumberIsReturnedWhenALocationIsProvided(): void
     {
         $fixture = new Class_($this->fqsen, $this->docBlock, null, false, false, new Location(100, 20));
 

--- a/tests/unit/phpDocumentor/Reflection/Php/ConstantTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/ConstantTest.php
@@ -44,7 +44,7 @@ final class ConstantTest extends TestCase
     /**
      * Creates a new (empty) fixture object.
      */
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->fqsen = new Fqsen('\MySpace\CONSTANT');
         $this->docBlock = new DocBlock('');
@@ -55,7 +55,7 @@ final class ConstantTest extends TestCase
      * @covers ::getValue
      * @covers ::__construct
      */
-    public function testGetValue() : void
+    public function testGetValue(): void
     {
         $this->assertSame($this->value, $this->fixture->getValue());
     }
@@ -64,7 +64,7 @@ final class ConstantTest extends TestCase
      * @covers ::getFqsen
      * @covers ::getName
      */
-    public function testGetFqsen() : void
+    public function testGetFqsen(): void
     {
         $this->assertSame($this->fqsen, $this->fixture->getFqsen());
         $this->assertSame($this->fqsen->getName(), $this->fixture->getName());
@@ -73,7 +73,7 @@ final class ConstantTest extends TestCase
     /**
      * @covers ::getDocBlock
      */
-    public function testGetDocblock() : void
+    public function testGetDocblock(): void
     {
         $this->assertSame($this->docBlock, $this->fixture->getDocBlock());
     }
@@ -81,7 +81,7 @@ final class ConstantTest extends TestCase
     /**
      * @covers ::getVisibility
      */
-    public function testGetVisibility() : void
+    public function testGetVisibility(): void
     {
         $this->assertEquals(new Visibility(Visibility::PUBLIC_), $this->fixture->getVisibility());
     }
@@ -89,7 +89,7 @@ final class ConstantTest extends TestCase
     /**
      * @covers ::getLocation
      */
-    public function testLineNumberIsMinusOneWhenNoneIsProvided() : void
+    public function testLineNumberIsMinusOneWhenNoneIsProvided(): void
     {
         $this->assertSame(-1, $this->fixture->getLocation()->getLineNumber());
         $this->assertSame(0, $this->fixture->getLocation()->getColumnNumber());
@@ -100,7 +100,7 @@ final class ConstantTest extends TestCase
      *
      * @covers ::getLocation
      */
-    public function testLineAndColumnNumberIsReturnedWhenALocationIsProvided() : void
+    public function testLineAndColumnNumberIsReturnedWhenALocationIsProvided(): void
     {
         $fixture = new Constant($this->fqsen, $this->docBlock, null, new Location(100, 20));
 

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/ArgumentTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/ArgumentTest.php
@@ -38,7 +38,7 @@ use stdClass;
  */
 class ArgumentTest extends TestCase
 {
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->fixture = new Argument(new PrettyPrinter());
     }
@@ -46,7 +46,7 @@ class ArgumentTest extends TestCase
     /**
      * @covers ::matches
      */
-    public function testMatches() : void
+    public function testMatches(): void
     {
         $this->assertFalse($this->fixture->matches(self::createContext(null), new stdClass()));
         $this->assertTrue($this->fixture->matches(self::createContext(null), m::mock(Param::class)));
@@ -55,7 +55,7 @@ class ArgumentTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testCreate() : void
+    public function testCreate(): void
     {
         $factory = new ProjectFactoryStrategies([]);
         $method = new MethodElement(new Fqsen('\Class::method()'));

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/ClassConstantIteratorTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/ClassConstantIteratorTest.php
@@ -36,7 +36,7 @@ final class ClassConstantIteratorTest extends MockeryTestCase
      * @covers ::getName()
      * @covers ::getFqsen()
      */
-    public function testIterateProps() : void
+    public function testIterateProps(): void
     {
         $const1 = new Const_('\Space\MyClass::MY_CONST1', new Variable('a'));
         $const1->fqsen = new Fqsen((string) $const1->name);
@@ -58,7 +58,7 @@ final class ClassConstantIteratorTest extends MockeryTestCase
      * @covers ::key()
      * @covers ::next()
      */
-    public function testKey() : void
+    public function testKey(): void
     {
         $constantMock = m::mock(ClassConst::class);
 
@@ -73,7 +73,7 @@ final class ClassConstantIteratorTest extends MockeryTestCase
      * @covers ::__construct
      * @covers ::getLine
      */
-    public function testProxyMethods() : void
+    public function testProxyMethods(): void
     {
         $constantMock = m::mock(ClassConst::class);
         $constantMock->shouldReceive('getLine')->once()->andReturn(10);
@@ -86,7 +86,7 @@ final class ClassConstantIteratorTest extends MockeryTestCase
     /**
      * @covers ::getDocComment
      */
-    public function testGetDocCommentPropFirst() : void
+    public function testGetDocCommentPropFirst(): void
     {
         $const = m::mock(Const_::class);
         $classConstants = m::mock(ClassConst::class);
@@ -103,7 +103,7 @@ final class ClassConstantIteratorTest extends MockeryTestCase
     /**
      * @covers ::getDocComment
      */
-    public function testGetDocComment() : void
+    public function testGetDocComment(): void
     {
         $const = m::mock(Const_::class);
         $classConstants = m::mock(ClassConst::class);

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/ClassConstantTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/ClassConstantTest.php
@@ -27,6 +27,7 @@ use PhpParser\Node\Stmt\ClassConst;
 use PhpParser\PrettyPrinter\Standard as PrettyPrinter;
 use Prophecy\Prophecy\ObjectProphecy;
 use stdClass;
+
 use function current;
 
 /**

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/ClassConstantTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/ClassConstantTest.php
@@ -43,7 +43,7 @@ final class ClassConstantTest extends TestCase
     /** @var ObjectProphecy */
     private $docBlockFactory;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->docBlockFactory = $this->prophesize(DocBlockFactoryInterface::class);
         $this->fixture = new ClassConstant(
@@ -52,14 +52,14 @@ final class ClassConstantTest extends TestCase
         );
     }
 
-    public function testMatches() : void
+    public function testMatches(): void
     {
         $this->assertFalse($this->fixture->matches(self::createContext(null), new stdClass()));
         $this->assertTrue($this->fixture->matches(self::createContext(null), $this->buildConstantIteratorStub()));
     }
 
     /** @dataProvider visibilityProvider */
-    public function testCreateWithVisibility(int $input, string $expectedVisibility) : void
+    public function testCreateWithVisibility(int $input, string $expectedVisibility): void
     {
         $constantStub = $this->buildConstantIteratorStub($input);
 
@@ -70,7 +70,7 @@ final class ClassConstantTest extends TestCase
     }
 
     /** @return array<string|int[]> */
-    public function visibilityProvider() : array
+    public function visibilityProvider(): array
     {
         return [
             [
@@ -88,7 +88,7 @@ final class ClassConstantTest extends TestCase
         ];
     }
 
-    public function testCreateWithDocBlock() : void
+    public function testCreateWithDocBlock(): void
     {
         $doc = new Doc('text');
         $docBlock = new DocBlockDescriptor('text');
@@ -105,7 +105,7 @@ final class ClassConstantTest extends TestCase
         $this->assertSame($docBlock, $constant->getDocBlock());
     }
 
-    private function buildConstantIteratorStub(int $modifier = ClassNode::MODIFIER_PUBLIC) : ClassConst
+    private function buildConstantIteratorStub(int $modifier = ClassNode::MODIFIER_PUBLIC): ClassConst
     {
         $const = new Const_('\Space\MyClass::MY_CONST1', new String_('a'));
         $const->fqsen = new Fqsen((string) $const->name);
@@ -113,7 +113,7 @@ final class ClassConstantTest extends TestCase
         return new ClassConst([$const], $modifier);
     }
 
-    private function assertConstant(ConstantDescriptor $constant, string $visibility) : void
+    private function assertConstant(ConstantDescriptor $constant, string $visibility): void
     {
         $this->assertInstanceOf(ConstantDescriptor::class, $constant);
         $this->assertEquals('\Space\MyClass::MY_CONST1', (string) $constant->getFqsen());
@@ -121,7 +121,7 @@ final class ClassConstantTest extends TestCase
         $this->assertEquals($visibility, (string) $constant->getVisibility());
     }
 
-    private function performCreate(ClassConst $constantStub) : ClassElement
+    private function performCreate(ClassConst $constantStub): ClassElement
     {
         $factory = new ProjectFactoryStrategies([]);
         $class = new ClassElement(new Fqsen('\myClass'));

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/Class_Test.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/Class_Test.php
@@ -29,6 +29,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use stdClass;
+
 use function current;
 
 /**

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/Class_Test.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/Class_Test.php
@@ -51,7 +51,7 @@ final class Class_Test extends TestCase
     /** @var ObjectProphecy */
     private $docblockFactory;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->docblockFactory = $this->prophesize(DocBlockFactoryInterface::class);
         $this->fixture = new Class_($this->docblockFactory->reveal());
@@ -60,7 +60,7 @@ final class Class_Test extends TestCase
     /**
      * @covers ::matches
      */
-    public function testMatches() : void
+    public function testMatches(): void
     {
         $this->assertFalse($this->fixture->matches(self::createContext(null), new stdClass()));
         $this->assertTrue(
@@ -74,7 +74,7 @@ final class Class_Test extends TestCase
     /**
      * @covers ::create
      */
-    public function testSimpleCreate() : void
+    public function testSimpleCreate(): void
     {
         $containerMock = m::mock(StrategyContainer::class);
         $classMock     = $this->buildClassMock();
@@ -92,7 +92,7 @@ final class Class_Test extends TestCase
     /**
      * @covers ::create
      */
-    public function testClassWithParent() : void
+    public function testClassWithParent(): void
     {
         $containerMock = m::mock(StrategyContainer::class);
         $classMock     = $this->buildClassMock();
@@ -109,7 +109,7 @@ final class Class_Test extends TestCase
     /**
      * @covers ::create
      */
-    public function testClassImplementingInterface() : void
+    public function testClassImplementingInterface(): void
     {
         $containerMock = m::mock(StrategyContainer::class);
         $classMock     = $this->buildClassMock();
@@ -133,7 +133,7 @@ final class Class_Test extends TestCase
     /**
      * @covers ::create
      */
-    public function testIteratesStatements() : void
+    public function testIteratesStatements(): void
     {
         $method1           = new ClassMethod('MyClass::method1');
         $method1Descriptor = new MethodElement(new Fqsen('\MyClass::method1'));
@@ -144,7 +144,7 @@ final class Class_Test extends TestCase
         $classMock->stmts = [$method1];
 
         $strategyMock->create(Argument::type(ContextStack::class), $method1, $containerMock)
-            ->will(function ($args) use ($method1Descriptor) : void {
+            ->will(function ($args) use ($method1Descriptor): void {
                 $args[0]->peek()->addMethod($method1Descriptor);
             })
             ->shouldBeCalled();
@@ -167,7 +167,7 @@ final class Class_Test extends TestCase
     /**
      * @covers ::create
      */
-    public function testCreateWithDocBlock() : void
+    public function testCreateWithDocBlock(): void
     {
         $doc       = new Doc('Text');
         $classMock = $this->buildClassMock();
@@ -195,7 +195,7 @@ final class Class_Test extends TestCase
         return $classMock;
     }
 
-    private function performCreate(ClassNode $classMock, StrategyContainer $containerMock) : ClassElement
+    private function performCreate(ClassNode $classMock, StrategyContainer $containerMock): ClassElement
     {
         $file = new File('hash', 'path');
         $this->fixture->create(self::createContext(null)->push($file), $classMock, $containerMock);

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/ConstructorPromotionTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/ConstructorPromotionTest.php
@@ -37,7 +37,7 @@ final class ConstructorPromotionTest extends TestCase
     /** @var ObjectProphecy */
     private $docblockFactory;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->strategy        = $this->prophesize(ProjectFactoryStrategy::class);
         $this->docblockFactory = $this->prophesize(DocBlockFactoryInterface::class);
@@ -56,7 +56,7 @@ final class ConstructorPromotionTest extends TestCase
      * @covers ::__construct
      * @covers ::matches
      */
-    public function testMatches(ContextStack $context, object $object, bool $expected) : void
+    public function testMatches(ContextStack $context, object $object, bool $expected): void
     {
         self::assertEquals($expected, $this->fixture->matches($context, $object));
     }
@@ -64,7 +64,7 @@ final class ConstructorPromotionTest extends TestCase
     /**
      * @return mixed[][]
      */
-    public function objectProvider() : array
+    public function objectProvider(): array
     {
         $context = new ContextStack(new Project('test'));
 
@@ -98,7 +98,7 @@ final class ConstructorPromotionTest extends TestCase
      * @covers ::promoteParameterToProperty
      * @dataProvider visibilityProvider
      */
-    public function testCreateWithProperty(int $flags, string $visibility) : void
+    public function testCreateWithProperty(int $flags, string $visibility): void
     {
         $methodNode         = new ClassMethod('__construct');
         $methodNode->params = [new Param(
@@ -140,7 +140,7 @@ final class ConstructorPromotionTest extends TestCase
     }
 
     /** @return mixed[][] */
-    public function visibilityProvider() : array
+    public function visibilityProvider(): array
     {
         return [
             [

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/ConstructorPromotionTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/ConstructorPromotionTest.php
@@ -25,6 +25,7 @@ use PhpParser\PrettyPrinter\Standard;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use stdClass;
+
 use function current;
 
 /**

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/ConstructorPromotionTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/ConstructorPromotionTest.php
@@ -102,19 +102,20 @@ final class ConstructorPromotionTest extends TestCase
     public function testCreateWithProperty(int $flags, string $visibility): void
     {
         $methodNode         = new ClassMethod('__construct');
-        $methodNode->params = [new Param(
-            new Variable('myArgument'),
-            new String_('MyDefault'),
-            new Identifier('string'),
-            false,
-            false,
-            [
-                'comments' => [
-                    new Doc('text'),
+        $methodNode->params = [
+            new Param(
+                new Variable('myArgument'),
+                new String_('MyDefault'),
+                new Identifier('string'),
+                false,
+                false,
+                [
+                    'comments' => [
+                        new Doc('text'),
+                    ],
                 ],
-            ],
-            $flags
-        ),
+                $flags
+            ),
         ];
 
         $docBlock = new DocBlock('Test');

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/ContextStackTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/ContextStackTest.php
@@ -21,7 +21,7 @@ final class ContextStackTest extends PHPUnitTestCase
      * @covers ::getTypeContext
      * @covers ::getProject
      */
-    public function testCreate() : void
+    public function testCreate(): void
     {
         $project = new Project('myProject');
         $typeContext = new Context('myNamespace');
@@ -35,7 +35,7 @@ final class ContextStackTest extends PHPUnitTestCase
      * @covers ::__construct
      * @covers ::peek
      */
-    public function testPeekThowsWhenEmpty() : void
+    public function testPeekThowsWhenEmpty(): void
     {
         $this->expectException(OutOfBoundsException::class);
         $project = new Project('myProject');
@@ -53,7 +53,7 @@ final class ContextStackTest extends PHPUnitTestCase
      * @covers ::getProject
      * @covers ::createFromSelf
      */
-    public function testPeekReturnsTopOfStack() : void
+    public function testPeekReturnsTopOfStack(): void
     {
         $class = new ClassElement(new Fqsen('\MyClass'));
 
@@ -76,7 +76,7 @@ final class ContextStackTest extends PHPUnitTestCase
      * @covers ::getProject
      * @covers ::createFromSelf
      */
-    public function testCreateWithTypeContext() : void
+    public function testCreateWithTypeContext(): void
     {
         $class = new ClassElement(new Fqsen('\MyClass'));
 

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/DefineTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/DefineTest.php
@@ -29,6 +29,7 @@ use PhpParser\Node\Stmt\Expression;
 use PhpParser\PrettyPrinter\Standard as PrettyPrinter;
 use Prophecy\Prophecy\ObjectProphecy;
 use stdClass;
+
 use function current;
 
 /**

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/DefineTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/DefineTest.php
@@ -44,13 +44,13 @@ final class DefineTest extends TestCase
     /** @var ObjectProphecy */
     private $docBlockFactory;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->docBlockFactory = $this->prophesize(DocBlockFactoryInterface::class);
         $this->fixture = new Define($this->docBlockFactory->reveal(), new PrettyPrinter());
     }
 
-    public function testMatches() : void
+    public function testMatches(): void
     {
         $invalidExpressionType = new Expression(new Exit_());
         $invalidFunctionCall = new Expression(new FuncCall(new Name('print')));
@@ -61,7 +61,7 @@ final class DefineTest extends TestCase
         $this->assertTrue($this->fixture->matches(self::createContext(null), $this->buildDefineStub()));
     }
 
-    public function testCreate() : void
+    public function testCreate(): void
     {
         $constantStub = $this->buildDefineStub();
         $file = new FileElement('hash', 'path');
@@ -74,7 +74,7 @@ final class DefineTest extends TestCase
         $this->assertConstant($constant, '');
     }
 
-    public function testCreateNamespace() : void
+    public function testCreateNamespace(): void
     {
         $constantStub = $this->buildDefineStub('\\OtherSpace\\MyClass');
         $file = new FileElement('hash', 'path');
@@ -87,7 +87,7 @@ final class DefineTest extends TestCase
         $this->assertConstant($constant, '\\OtherSpace\\MyClass');
     }
 
-    public function testCreateGlobal() : void
+    public function testCreateGlobal(): void
     {
         $constantStub = $this->buildDefineStub();
         $file = new FileElement('hash', 'path');
@@ -100,7 +100,7 @@ final class DefineTest extends TestCase
         $this->assertConstant($constant, '');
     }
 
-    public function testCreateWithDocBlock() : void
+    public function testCreateWithDocBlock(): void
     {
         $doc = new Doc('Text');
         $docBlock = new DocBlockDescriptor('');
@@ -129,7 +129,7 @@ final class DefineTest extends TestCase
         $this->assertSame($docBlock, $constant->getDocBlock());
     }
 
-    private function buildDefineStub(string $namespace = '') : Expression
+    private function buildDefineStub(string $namespace = ''): Expression
     {
         return new Expression(
             new FuncCall(
@@ -142,7 +142,7 @@ final class DefineTest extends TestCase
         );
     }
 
-    private function assertConstant(ConstantDescriptor $constant, string $namespace) : void
+    private function assertConstant(ConstantDescriptor $constant, string $namespace): void
     {
         $this->assertInstanceOf(ConstantDescriptor::class, $constant);
         $this->assertEquals($namespace . '\\MY_CONST1', (string) $constant->getFqsen());

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/DummyFactoryStrategy.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/DummyFactoryStrategy.php
@@ -25,7 +25,7 @@ final class DummyFactoryStrategy implements ProjectFactoryStrategy
      *
      * @param mixed $object object to check.
      */
-    public function matches(ContextStack $context, object $object) : bool
+    public function matches(ContextStack $context, object $object): bool
     {
         return true;
     }
@@ -41,7 +41,7 @@ final class DummyFactoryStrategy implements ProjectFactoryStrategy
      *
      * @return mixed
      */
-    public function create(ContextStack $context, object $object, StrategyContainer $strategies) : void
+    public function create(ContextStack $context, object $object, StrategyContainer $strategies): void
     {
     }
 }

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/File/CreateCommandTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/File/CreateCommandTest.php
@@ -37,7 +37,7 @@ class CreateCommandTest extends TestCase
     /** @var ProjectFactoryStrategies */
     private $strategies;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->file       = new LocalFile(__FILE__);
         $this->strategies = new ProjectFactoryStrategies([]);
@@ -51,7 +51,7 @@ class CreateCommandTest extends TestCase
     /**
      * @covers ::getFile
      */
-    public function testGetFile() : void
+    public function testGetFile(): void
     {
         $this->assertSame($this->file, $this->fixture->getFile());
     }
@@ -59,7 +59,7 @@ class CreateCommandTest extends TestCase
     /**
      * @covers ::getStrategies
      */
-    public function testGetStrategies() : void
+    public function testGetStrategies(): void
     {
         $this->assertSame($this->strategies, $this->fixture->getStrategies());
     }

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/FileTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/FileTest.php
@@ -64,7 +64,7 @@ final class FileTest extends TestCase
     /** @var ObjectProphecy */
     private $docBlockFactory;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->docBlockFactory = $this->prophesize(DocBlockFactoryInterface::class);
         $this->nodesFactoryMock = $this->prophesize(NodesFactory::class);
@@ -74,7 +74,7 @@ final class FileTest extends TestCase
     /**
      * @covers ::matches
      */
-    public function testMatches() : void
+    public function testMatches(): void
     {
         $this->assertFalse($this->fixture->matches(self::createContext(null), new stdClass()));
         $this->assertTrue($this->fixture->matches(self::createContext(null), m::mock(SourceFile::class)));
@@ -83,7 +83,7 @@ final class FileTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testMiddlewareIsExecuted() : void
+    public function testMiddlewareIsExecuted(): void
     {
         $file = new FileElement('aa', __FILE__);
         $this->nodesFactoryMock->create(file_get_contents(__FILE__))->willReturn([]);
@@ -103,7 +103,7 @@ final class FileTest extends TestCase
         $this->assertSame($result, $file);
     }
 
-    public function testMiddlewareIsChecked() : void
+    public function testMiddlewareIsChecked(): void
     {
         $this->expectException('InvalidArgumentException');
         new File($this->docBlockFactory->reveal(), $this->nodesFactoryMock->reveal(), [new stdClass()]);
@@ -113,7 +113,7 @@ final class FileTest extends TestCase
      * @covers ::create
      * @dataProvider nodeProvider
      */
-    public function testFileGetsCommentFromFirstNode(Node $node, DocBlockDescriptor $docblock) : void
+    public function testFileGetsCommentFromFirstNode(Node $node, DocBlockDescriptor $docblock): void
     {
         $this->nodesFactoryMock->create(file_get_contents(__FILE__))->willReturn([$node]);
         $this->docBlockFactory->create('Text', null)->willReturn($docblock);
@@ -133,7 +133,7 @@ final class FileTest extends TestCase
     }
 
     /** @return array<string, mixed[]> */
-    public function nodeProvider() : array
+    public function nodeProvider(): array
     {
         $docBlockNode = new DocBlockNode('Text');
         $namespaceNode = new NamespaceNode(new Name('mySpace'));

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/FileTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/FileTest.php
@@ -32,6 +32,7 @@ use PhpParser\Node\Stmt\Namespace_ as NamespaceNode;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use stdClass;
+
 use function current;
 use function file_get_contents;
 

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/Function_Test.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/Function_Test.php
@@ -44,7 +44,7 @@ final class Function_Test extends TestCase
     /** @var ObjectProphecy */
     private $docBlockFactory;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->docBlockFactory = $this->prophesize(DocBlockFactoryInterface::class);
         $this->fixture = new Function_($this->docBlockFactory->reveal());
@@ -53,7 +53,7 @@ final class Function_Test extends TestCase
     /**
      * @covers ::matches
      */
-    public function testMatches() : void
+    public function testMatches(): void
     {
         $this->assertFalse($this->fixture->matches(self::createContext(null), new stdClass()));
         $this->assertTrue($this->fixture->matches(
@@ -65,7 +65,7 @@ final class Function_Test extends TestCase
     /**
      * @covers ::create
      */
-    public function testCreateWithoutParameters() : void
+    public function testCreateWithoutParameters(): void
     {
         $functionMock = $this->prophesize(\PhpParser\Node\Stmt\Function_::class);
         $functionMock->fqsen = new Fqsen('\SomeSpace::function()');
@@ -87,7 +87,7 @@ final class Function_Test extends TestCase
     /**
      * @covers ::create
      */
-    public function testCreateWithParameters() : void
+    public function testCreateWithParameters(): void
     {
         $param1 = new Param(new Variable('param1'));
         $functionMock = $this->prophesize(\PhpParser\Node\Stmt\Function_::class);
@@ -125,7 +125,7 @@ final class Function_Test extends TestCase
     /**
      * @covers ::create
      */
-    public function testCreateWithDocBlock() : void
+    public function testCreateWithDocBlock(): void
     {
         $doc = new Doc('Text');
         $functionMock = $this->prophesize(\PhpParser\Node\Stmt\Function_::class);

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/Function_Test.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/Function_Test.php
@@ -26,6 +26,7 @@ use PhpParser\Node\Param;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use stdClass;
+
 use function current;
 
 /**

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/GlobalConstantIteratorTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/GlobalConstantIteratorTest.php
@@ -35,7 +35,7 @@ final class GlobalConstantIteratorTest extends m\Adapter\Phpunit\MockeryTestCase
      * @covers ::getName()
      * @covers ::getFqsen()
      */
-    public function testIterateProps() : void
+    public function testIterateProps(): void
     {
         $const1 = new Const_('\Space\MY_CONST1', new Variable('a'));
         $const1->fqsen = new Fqsen((string) $const1->name);
@@ -57,7 +57,7 @@ final class GlobalConstantIteratorTest extends m\Adapter\Phpunit\MockeryTestCase
      * @covers ::key()
      * @covers ::next()
      */
-    public function testKey() : void
+    public function testKey(): void
     {
         $constant = m::mock(ConstStatement::class);
 
@@ -72,7 +72,7 @@ final class GlobalConstantIteratorTest extends m\Adapter\Phpunit\MockeryTestCase
      * @covers ::__construct
      * @covers ::getLine
      */
-    public function testProxyMethods() : void
+    public function testProxyMethods(): void
     {
         $constant = m::mock(ConstStatement::class);
         $constant->shouldReceive('getLine')->once()->andReturn(10);
@@ -85,7 +85,7 @@ final class GlobalConstantIteratorTest extends m\Adapter\Phpunit\MockeryTestCase
     /**
      * @covers ::getDocComment
      */
-    public function testGetDocCommentPropFirst() : void
+    public function testGetDocCommentPropFirst(): void
     {
         $const = m::mock(Const_::class);
         $constants = m::mock(ConstStatement::class);
@@ -102,7 +102,7 @@ final class GlobalConstantIteratorTest extends m\Adapter\Phpunit\MockeryTestCase
     /**
      * @covers ::getDocComment
      */
-    public function testGetDocComment() : void
+    public function testGetDocComment(): void
     {
         $const = m::mock(Const_::class);
         $constants = m::mock(ConstStatement::class);

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/GlobalConstantTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/GlobalConstantTest.php
@@ -28,6 +28,7 @@ use PhpParser\Node\Stmt\Const_ as ConstStatement;
 use PhpParser\PrettyPrinter\Standard as PrettyPrinter;
 use Prophecy\Prophecy\ObjectProphecy;
 use stdClass;
+
 use function current;
 
 /**

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/GlobalConstantTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/GlobalConstantTest.php
@@ -44,19 +44,19 @@ final class GlobalConstantTest extends TestCase
     /** @var ObjectProphecy */
     private $docBlockFactory;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->docBlockFactory = $this->prophesize(DocBlockFactoryInterface::class);
         $this->fixture = new GlobalConstant($this->docBlockFactory->reveal(), new PrettyPrinter());
     }
 
-    public function testMatches() : void
+    public function testMatches(): void
     {
         $this->assertFalse($this->fixture->matches(self::createContext(null), new stdClass()));
         $this->assertTrue($this->fixture->matches(self::createContext(null), $this->buildConstantIteratorStub()));
     }
 
-    public function testCreate() : void
+    public function testCreate(): void
     {
         $factory = new ProjectFactoryStrategies([]);
 
@@ -69,7 +69,7 @@ final class GlobalConstantTest extends TestCase
         $this->assertConstant($constant);
     }
 
-    public function testCreateWithDocBlock() : void
+    public function testCreateWithDocBlock(): void
     {
         $doc = new Doc('Text');
         $docBlock = new DocBlockDescriptor('');
@@ -89,7 +89,7 @@ final class GlobalConstantTest extends TestCase
         $this->assertSame($docBlock, $constant->getDocBlock());
     }
 
-    private function buildConstantIteratorStub() : ConstStatement
+    private function buildConstantIteratorStub(): ConstStatement
     {
         $const = new Const_('\Space\MyClass\MY_CONST1', new String_('a'));
         $const->fqsen = new Fqsen((string) $const->name);
@@ -97,7 +97,7 @@ final class GlobalConstantTest extends TestCase
         return new ConstStatement([$const]);
     }
 
-    private function assertConstant(ConstantDescriptor $constant) : void
+    private function assertConstant(ConstantDescriptor $constant): void
     {
         $this->assertInstanceOf(ConstantDescriptor::class, $constant);
         $this->assertEquals('\Space\MyClass\MY_CONST1', (string) $constant->getFqsen());

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/Interface_Test.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/Interface_Test.php
@@ -28,6 +28,7 @@ use PhpParser\Node\Stmt\Interface_ as InterfaceNode;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use stdClass;
+
 use function current;
 
 /**

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/Interface_Test.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/Interface_Test.php
@@ -48,7 +48,7 @@ class Interface_Test extends TestCase
     /** @var ObjectProphecy */
     private $docBlockFactory;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->docBlockFactory = $this->prophesize(DocBlockFactoryInterface::class);
         $this->fixture = new Interface_($this->docBlockFactory->reveal());
@@ -57,7 +57,7 @@ class Interface_Test extends TestCase
     /**
      * @covers ::matches
      */
-    public function testMatches() : void
+    public function testMatches(): void
     {
         $this->assertFalse($this->fixture->matches(self::createContext(null), new stdClass()));
         $this->assertTrue($this->fixture->matches(self::createContext(null), m::mock(InterfaceNode::class)));
@@ -66,7 +66,7 @@ class Interface_Test extends TestCase
     /**
      * @covers ::create
      */
-    public function testSimpleCreate() : void
+    public function testSimpleCreate(): void
     {
         $interfaceMock = $this->buildClassMock();
         $interfaceMock->shouldReceive('getDocComment')->andReturnNull();
@@ -81,7 +81,7 @@ class Interface_Test extends TestCase
     /**
      * @covers ::create
      */
-    public function testCreateWithDocBlock() : void
+    public function testCreateWithDocBlock(): void
     {
         $doc           = new Doc('Text');
         $docBlock      = new DocBlockElement('');
@@ -99,7 +99,7 @@ class Interface_Test extends TestCase
     /**
      * @covers ::create
      */
-    public function testIteratesStatements() : void
+    public function testIteratesStatements(): void
     {
         $method1           = new ClassMethod('MyClass::method1');
         $method1Descriptor = new MethodElement(new Fqsen('\MyClass::method1'));
@@ -110,7 +110,7 @@ class Interface_Test extends TestCase
         $classMock->stmts = [$method1];
 
         $strategyMock->create(Argument::type(ContextStack::class), $method1, $containerMock)
-            ->will(function ($args) use ($method1Descriptor) : void {
+            ->will(function ($args) use ($method1Descriptor): void {
                 $args[0]->peek()->addMethod($method1Descriptor);
             })
             ->shouldBeCalled();
@@ -143,7 +143,7 @@ class Interface_Test extends TestCase
         return $interfaceMock;
     }
 
-    private function performCreate(m\MockInterface $interfaceMock, StrategyContainer $containerMock) : InterfaceElement
+    private function performCreate(m\MockInterface $interfaceMock, StrategyContainer $containerMock): InterfaceElement
     {
         $file = new FileElement('hash', 'path');
         $this->fixture->create(

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/MethodTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/MethodTest.php
@@ -48,7 +48,7 @@ class MethodTest extends TestCase
     /** @var ObjectProphecy */
     private $docBlockFactory;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->docBlockFactory = $this->prophesize(DocBlockFactoryInterface::class);
         $this->fixture = new Method($this->docBlockFactory->reveal());
@@ -57,7 +57,7 @@ class MethodTest extends TestCase
     /**
      * @covers ::matches
      */
-    public function testMatches() : void
+    public function testMatches(): void
     {
         $this->assertFalse($this->fixture->matches(self::createContext(null), new stdClass()));
         $this->assertTrue($this->fixture->matches(self::createContext(null), m::mock(ClassMethod::class)));
@@ -66,7 +66,7 @@ class MethodTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testCreateWithoutParameters() : void
+    public function testCreateWithoutParameters(): void
     {
         $classMethodMock = $this->buildClassMethodMock();
         $classMethodMock->params = [];
@@ -90,7 +90,7 @@ class MethodTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testCreateProtectedMethod() : void
+    public function testCreateProtectedMethod(): void
     {
         $classMethodMock = $this->buildClassMethodMock();
         $classMethodMock->params = [];
@@ -114,7 +114,7 @@ class MethodTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testCreateWithParameters() : void
+    public function testCreateWithParameters(): void
     {
         $param1 = new Param(new Variable('param1'));
         $classMethodMock = $this->buildClassMethodMock();
@@ -153,7 +153,7 @@ class MethodTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testCreateWithDocBlock() : void
+    public function testCreateWithDocBlock(): void
     {
         $doc = new Doc('Text');
         $classMethodMock = $this->buildClassMethodMock();
@@ -178,7 +178,7 @@ class MethodTest extends TestCase
     /**
      * @return MockInterface|ClassMethod
      */
-    private function buildClassMethodMock() : MockInterface
+    private function buildClassMethodMock(): MockInterface
     {
         $methodMock = m::mock(ClassMethod::class);
         $methodMock->name = 'function';

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/MethodTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/MethodTest.php
@@ -29,6 +29,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use stdClass;
+
 use function current;
 
 /**

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/Namespace_Test.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/Namespace_Test.php
@@ -21,7 +21,7 @@ use function current;
  */
 final class Namespace_Test extends TestCase
 {
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->fixture = new Namespace_();
     }
@@ -29,7 +29,7 @@ final class Namespace_Test extends TestCase
     /**
      * @covers ::matches
      */
-    public function testMatches() : void
+    public function testMatches(): void
     {
         $this->assertFalse($this->fixture->matches(self::createContext(null), new stdClass()));
         $this->assertTrue($this->fixture->matches(
@@ -41,7 +41,7 @@ final class Namespace_Test extends TestCase
     /**
      * @covers ::create
      */
-    public function testCreateThrowsException() : void
+    public function testCreateThrowsException(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->fixture->create(
@@ -54,7 +54,7 @@ final class Namespace_Test extends TestCase
     /**
      * @covers ::create
      */
-    public function testIteratesStatements() : void
+    public function testIteratesStatements(): void
     {
         $class           = new ClassNode('\MyClass');
         $classElement = new ClassElement(new Fqsen('\MyClass'));
@@ -65,7 +65,7 @@ final class Namespace_Test extends TestCase
         $namespace->stmts = [$class];
 
         $strategyMock->create(Argument::type(ContextStack::class), $class, $containerMock)
-            ->will(function ($args) use ($classElement) : void {
+            ->will(function ($args) use ($classElement): void {
                 $args[0]->peek()->addClass($classElement);
             })
             ->shouldBeCalled();

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/Namespace_Test.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/Namespace_Test.php
@@ -14,6 +14,7 @@ use PhpParser\Node\Stmt\Class_ as ClassNode;
 use PhpParser\Node\Stmt\Namespace_ as NamespaceNode;
 use Prophecy\Argument;
 use stdClass;
+
 use function current;
 
 /**

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/PropertyIteratorTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/PropertyIteratorTest.php
@@ -33,7 +33,7 @@ class PropertyIteratorTest extends MockeryTestCase
      * @covers ::rewind()
      * @covers ::getName()
      */
-    public function testIterateProps() : void
+    public function testIterateProps(): void
     {
         $prop1 = new PropertyProperty('prop1');
         $prop2 = new PropertyProperty('prop2');
@@ -51,7 +51,7 @@ class PropertyIteratorTest extends MockeryTestCase
      * @covers ::key()
      * @covers ::next()
      */
-    public function testKey() : void
+    public function testKey(): void
     {
         $propertyMock = m::mock(PropertyNode::class);
 
@@ -70,7 +70,7 @@ class PropertyIteratorTest extends MockeryTestCase
      * @covers ::isStatic
      * @covers ::getLine
      */
-    public function testProxyMethods() : void
+    public function testProxyMethods(): void
     {
         $propertyMock = m::mock(PropertyNode::class);
         $propertyMock->shouldReceive('isPublic')->once()->andReturn(true);
@@ -92,7 +92,7 @@ class PropertyIteratorTest extends MockeryTestCase
      * @covers ::__construct
      * @covers ::getDefault
      */
-    public function testGetDefault() : void
+    public function testGetDefault(): void
     {
         $prop = m::mock(PropertyProperty::class);
         $prop->default = 'myDefault';
@@ -106,7 +106,7 @@ class PropertyIteratorTest extends MockeryTestCase
     /**
      * @covers ::getDocComment
      */
-    public function testGetDocCommentPropFirst() : void
+    public function testGetDocCommentPropFirst(): void
     {
         $prop = m::mock(PropertyProperty::class);
         $propertyNode = m::mock(PropertyNode::class);
@@ -123,7 +123,7 @@ class PropertyIteratorTest extends MockeryTestCase
     /**
      * @covers ::getDocComment
      */
-    public function testGetDocComment() : void
+    public function testGetDocComment(): void
     {
         $prop = m::mock(PropertyProperty::class);
         $propertyNode = m::mock(PropertyNode::class);

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/PropertyTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/PropertyTest.php
@@ -44,20 +44,20 @@ final class PropertyTest extends TestCase
     /** @var ObjectProphecy */
     private $docBlockFactory;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->docBlockFactory = $this->prophesize(DocBlockFactoryInterface::class);
         $this->fixture = new Property($this->docBlockFactory->reveal(), new PrettyPrinter());
     }
 
-    public function testMatches() : void
+    public function testMatches(): void
     {
         $this->assertFalse($this->fixture->matches(self::createContext(null), new stdClass()));
         $this->assertTrue($this->fixture->matches(self::createContext(null), new PropertyNode(1, [])));
     }
 
     /** @dataProvider visibilityProvider */
-    public function testCreateWithVisibility(int $input, string $expectedVisibility) : void
+    public function testCreateWithVisibility(int $input, string $expectedVisibility): void
     {
         $constantStub = $this->buildPropertyMock($input);
 
@@ -68,7 +68,7 @@ final class PropertyTest extends TestCase
     }
 
     /** @return array<string|int[]> */
-    public function visibilityProvider() : array
+    public function visibilityProvider(): array
     {
         return [
             [
@@ -86,7 +86,7 @@ final class PropertyTest extends TestCase
         ];
     }
 
-    public function testCreateWithDocBlock() : void
+    public function testCreateWithDocBlock(): void
     {
         $doc = new Doc('text');
         $docBlock = new DocBlockDescriptor('text');
@@ -102,7 +102,7 @@ final class PropertyTest extends TestCase
         $this->assertSame($docBlock, $property->getDocBlock());
     }
 
-    private function buildPropertyMock(int $modifier) : PropertyNode
+    private function buildPropertyMock(int $modifier): PropertyNode
     {
         $property        = new PropertyProperty('property', new String_('MyDefault'));
         $property->fqsen = new Fqsen('\myClass::$property');
@@ -110,7 +110,7 @@ final class PropertyTest extends TestCase
         return new PropertyNode($modifier | ClassNode::MODIFIER_STATIC, [$property]);
     }
 
-    private function assertProperty(PropertyDescriptor $property, string $visibility) : void
+    private function assertProperty(PropertyDescriptor $property, string $visibility): void
     {
         $this->assertInstanceOf(PropertyDescriptor::class, $property);
         $this->assertEquals('\myClass::$property', (string) $property->getFqsen());
@@ -119,7 +119,7 @@ final class PropertyTest extends TestCase
         $this->assertEquals($visibility, (string) $property->getVisibility());
     }
 
-    private function performCreate(PropertyNode $property) : ClassElement
+    private function performCreate(PropertyNode $property): ClassElement
     {
         $factory = new ProjectFactoryStrategies([]);
         $class = new ClassElement(new Fqsen('\myClass'));

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/PropertyTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/PropertyTest.php
@@ -27,6 +27,7 @@ use PhpParser\Node\Stmt\PropertyProperty;
 use PhpParser\PrettyPrinter\Standard as PrettyPrinter;
 use Prophecy\Prophecy\ObjectProphecy;
 use stdClass;
+
 use function current;
 
 /**

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/TestCase.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/TestCase.php
@@ -29,7 +29,7 @@ abstract class TestCase extends MockeryTestCase
     /** @var ProjectFactoryStrategy */
     protected $fixture;
 
-    public static function createContext(?Context $typeContext = null) : ContextStack
+    public static function createContext(?Context $typeContext = null): ContextStack
     {
         return new ContextStack(
             new Project('test'),
@@ -40,7 +40,7 @@ abstract class TestCase extends MockeryTestCase
     /**
      * @covers \phpDocumentor\Reflection\Php\Factory\AbstractFactory::create
      */
-    public function testCreateThrowsException() : void
+    public function testCreateThrowsException(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->fixture->create(self::createContext(null), new stdClass(), m::mock(StrategyContainer::class));

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/TraitUseTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/TraitUseTest.php
@@ -20,7 +20,7 @@ use PhpParser\Node\Stmt\TraitUse as TraitUseNode;
 final class TraitUseTest extends TestCase
 {
     /** @return mixed[][] */
-    public function consumerProvider() : array
+    public function consumerProvider(): array
     {
         return [
             [new Class_Element(new Fqsen('\MyClass'))],
@@ -28,7 +28,7 @@ final class TraitUseTest extends TestCase
         ];
     }
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->fixture = new TraitUse();
     }
@@ -36,7 +36,7 @@ final class TraitUseTest extends TestCase
     /**
      * @covers ::matches
      */
-    public function testMatchesOnlyTraitUseNode() : void
+    public function testMatchesOnlyTraitUseNode(): void
     {
         self::assertTrue(
             $this->fixture->matches(
@@ -47,7 +47,7 @@ final class TraitUseTest extends TestCase
     }
 
     /** @covers ::create */
-    public function testCreateThrowsExceptionWhenStackDoesNotContainClass() : void
+    public function testCreateThrowsExceptionWhenStackDoesNotContainClass(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -61,7 +61,7 @@ final class TraitUseTest extends TestCase
      * @covers ::create
      * @dataProvider consumerProvider
      */
-    public function testCreateWillAddUsedTraitToContextTop(Element $traitConsumer) : void
+    public function testCreateWillAddUsedTraitToContextTop(Element $traitConsumer): void
     {
         $context = self::createContext()->push($traitConsumer);
         $this->fixture->create($context, $this->givenTraitUse(), new ProjectFactoryStrategies([]));
@@ -69,7 +69,7 @@ final class TraitUseTest extends TestCase
         self::assertEquals(['\Foo' => new Fqsen('\Foo')], $traitConsumer->getUsedTraits());
     }
 
-    private function givenTraitUse() : TraitUseNode
+    private function givenTraitUse(): TraitUseNode
     {
         return new TraitUseNode([new FullyQualified('Foo')]);
     }

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/Trait_Test.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/Trait_Test.php
@@ -46,13 +46,13 @@ final class Trait_Test extends TestCase
     /** @var ObjectProphecy */
     private $docBlockFactory;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->docBlockFactory = $this->prophesize(DocBlockFactoryInterface::class);
         $this->fixture = new Trait_($this->docBlockFactory->reveal());
     }
 
-    public function testMatches() : void
+    public function testMatches(): void
     {
         $this->assertFalse($this->fixture->matches(self::createContext(null), new stdClass()));
         $this->assertTrue($this->fixture->matches(self::createContext(null), m::mock(TraitNode::class)));
@@ -62,7 +62,7 @@ final class Trait_Test extends TestCase
      * @covers ::create
      * @covers ::doCreate
      */
-    public function testSimpleCreate() : void
+    public function testSimpleCreate(): void
     {
         $containerMock = m::mock(StrategyContainer::class);
         $interfaceMock = $this->buildTraitMock();
@@ -78,7 +78,7 @@ final class Trait_Test extends TestCase
      * @covers ::create
      * @covers ::doCreate
      */
-    public function testIteratesStatements() : void
+    public function testIteratesStatements(): void
     {
         $method1           = new ClassMethod('\Space\MyTrait::method1');
         $method1Descriptor = new MethodElement(new Fqsen('\Space\MyTrait::method1'));
@@ -89,7 +89,7 @@ final class Trait_Test extends TestCase
         $classMock->stmts = [$method1];
 
         $strategyMock->create(Argument::type(ContextStack::class), $method1, $containerMock)
-            ->will(function ($args) use ($method1Descriptor) : void {
+            ->will(function ($args) use ($method1Descriptor): void {
                 $args[0]->peek()->addMethod($method1Descriptor);
             })
             ->shouldBeCalled();
@@ -111,7 +111,7 @@ final class Trait_Test extends TestCase
     /**
      * @covers ::create
      */
-    public function testCreateWithDocBlock() : void
+    public function testCreateWithDocBlock(): void
     {
         $doc       = new Doc('Text');
         $traitMock = $this->buildTraitMock();
@@ -137,7 +137,7 @@ final class Trait_Test extends TestCase
         return $mock;
     }
 
-    private function performCreate(TraitNode $traitNode, StrategyContainer $containerMock) : TraitElement
+    private function performCreate(TraitNode $traitNode, StrategyContainer $containerMock): TraitElement
     {
         $file = new File('hash', 'path');
         $this->fixture->create(self::createContext(null)->push($file), $traitNode, $containerMock);

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/Trait_Test.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/Trait_Test.php
@@ -28,6 +28,7 @@ use PhpParser\Node\Stmt\Trait_ as TraitNode;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use stdClass;
+
 use function current;
 
 /**

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/TypeTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/TypeTest.php
@@ -33,7 +33,7 @@ final class TypeTest extends PhpUnitTestCase
     /**
      * @covers ::fromPhpParser
      */
-    public function testReturnsNullWhenNoTypeIsPassed() : void
+    public function testReturnsNullWhenNoTypeIsPassed(): void
     {
         $factory = new Type();
 
@@ -45,7 +45,7 @@ final class TypeTest extends PhpUnitTestCase
     /**
      * @covers ::fromPhpParser
      */
-    public function testReturnsReflectedType() : void
+    public function testReturnsReflectedType(): void
     {
         $factory = new Type();
         $given = new Name('integer');
@@ -59,7 +59,7 @@ final class TypeTest extends PhpUnitTestCase
     /**
      * @covers ::fromPhpParser
      */
-    public function testReturnsNullableTypeWhenPassedAPhpParserNullable() : void
+    public function testReturnsNullableTypeWhenPassedAPhpParserNullable(): void
     {
         $factory = new Type();
         $given = new NullableType('integer');
@@ -73,7 +73,7 @@ final class TypeTest extends PhpUnitTestCase
     /**
      * @covers ::fromPhpParser
      */
-    public function testReturnsUnion() : void
+    public function testReturnsUnion(): void
     {
         $factory = new Type();
         $given = new UnionType(['integer', 'string']);
@@ -87,7 +87,7 @@ final class TypeTest extends PhpUnitTestCase
     /**
      * @covers ::fromPhpParser
      */
-    public function testReturnsUnionGivenVariousTypes() : void
+    public function testReturnsUnionGivenVariousTypes(): void
     {
         $factory = new Type();
         $given = new UnionType(['integer', new Name('string'), new Identifier('float')]);

--- a/tests/unit/phpDocumentor/Reflection/Php/FileTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/FileTest.php
@@ -48,7 +48,7 @@ final class FileTest extends TestCase
     /**
      * Creates a new (emoty) fixture object.
      */
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->docBlock = new DocBlock('');
 
@@ -59,7 +59,7 @@ final class FileTest extends TestCase
      * @covers ::getClasses
      * @covers ::AddClass
      */
-    public function testAddAndGetClasses() : void
+    public function testAddAndGetClasses(): void
     {
         $this->assertEmpty($this->fixture->getClasses());
 
@@ -75,7 +75,7 @@ final class FileTest extends TestCase
      * @covers ::getConstants
      * @covers ::addConstant
      */
-    public function testAddAndGetConstants() : void
+    public function testAddAndGetConstants(): void
     {
         $this->assertEmpty($this->fixture->getConstants());
 
@@ -89,7 +89,7 @@ final class FileTest extends TestCase
      * @covers ::getFunctions
      * @covers ::addFunction
      */
-    public function testAddAndGetFunctions() : void
+    public function testAddAndGetFunctions(): void
     {
         $this->assertEmpty($this->fixture->getFunctions());
 
@@ -103,7 +103,7 @@ final class FileTest extends TestCase
      * @covers ::getInterfaces
      * @covers ::addInterface
      */
-    public function testAddAndGetInterfaces() : void
+    public function testAddAndGetInterfaces(): void
     {
         $this->assertEmpty($this->fixture->getInterfaces());
 
@@ -117,7 +117,7 @@ final class FileTest extends TestCase
      * @covers ::getTraits
      * @covers ::addTrait
      */
-    public function testAddAndGetTraits() : void
+    public function testAddAndGetTraits(): void
     {
         $this->assertEmpty($this->fixture->getTraits());
 
@@ -130,7 +130,7 @@ final class FileTest extends TestCase
     /**
      * @covers ::getDocBlock
      */
-    public function testGetDocBlock() : void
+    public function testGetDocBlock(): void
     {
         $this->assertSame($this->docBlock, $this->fixture->getDocBlock());
     }
@@ -138,7 +138,7 @@ final class FileTest extends TestCase
     /**
      * @covers ::getHash
      */
-    public function testGetHash() : void
+    public function testGetHash(): void
     {
         $this->assertSame(self::EXAMPLE_HASH, $this->fixture->getHash());
     }
@@ -146,7 +146,7 @@ final class FileTest extends TestCase
     /**
      * @covers ::getName
      */
-    public function testGetName() : void
+    public function testGetName(): void
     {
         $this->assertSame(self::EXAMPLE_NAME, $this->fixture->getName());
     }
@@ -154,7 +154,7 @@ final class FileTest extends TestCase
     /**
      * @covers ::getPath
      */
-    public function testSetAndGetPath() : void
+    public function testSetAndGetPath(): void
     {
         $this->assertSame(self::EXAMPLE_PATH, $this->fixture->getPath());
     }
@@ -162,7 +162,7 @@ final class FileTest extends TestCase
     /**
      * @covers ::getSource
      */
-    public function testSetAndGetSource() : void
+    public function testSetAndGetSource(): void
     {
         $this->assertSame(self::EXAMPLE_SOURCE, $this->fixture->getSource());
     }
@@ -171,7 +171,7 @@ final class FileTest extends TestCase
      * @covers ::addNamespace
      * @covers ::getNamespaces
      */
-    public function testSetAndGetNamespaceAliases() : void
+    public function testSetAndGetNamespaceAliases(): void
     {
         $this->assertEmpty($this->fixture->getNamespaces());
 
@@ -184,7 +184,7 @@ final class FileTest extends TestCase
      * @covers ::getIncludes
      * @covers ::addInclude
      */
-    public function testAddAndGetIncludes() : void
+    public function testAddAndGetIncludes(): void
     {
         $this->assertEmpty($this->fixture->getIncludes());
 

--- a/tests/unit/phpDocumentor/Reflection/Php/Function_Test.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Function_Test.php
@@ -43,7 +43,7 @@ final class Function_Test extends TestCase
     /**
      * Creates a new (empty) fixture object.
      */
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->fqsen = new Fqsen('\space\MyFunction()');
         $this->docBlock = new DocBlock('aa');
@@ -53,7 +53,7 @@ final class Function_Test extends TestCase
     /**
      * @covers ::getName
      */
-    public function testGetName() : void
+    public function testGetName(): void
     {
         $this->assertEquals('MyFunction', $this->fixture->getName());
     }
@@ -62,7 +62,7 @@ final class Function_Test extends TestCase
      * @covers ::addArgument
      * @covers ::getArguments
      */
-    public function testAddAndGetArguments() : void
+    public function testAddAndGetArguments(): void
     {
         $argument = new Argument('firstArgument');
         $this->fixture->addArgument($argument);
@@ -73,7 +73,7 @@ final class Function_Test extends TestCase
     /**
      * @covers ::getFqsen
      */
-    public function testGetFqsen() : void
+    public function testGetFqsen(): void
     {
         $this->assertSame($this->fqsen, $this->fixture->getFqsen());
     }
@@ -81,7 +81,7 @@ final class Function_Test extends TestCase
     /**
      * @covers ::getDocBlock
      */
-    public function testGetDocblock() : void
+    public function testGetDocblock(): void
     {
         $this->assertSame($this->docBlock, $this->fixture->getDocBlock());
     }
@@ -89,7 +89,7 @@ final class Function_Test extends TestCase
     /**
      * @covers ::getReturnType
      */
-    public function testGetDefaultReturnType() : void
+    public function testGetDefaultReturnType(): void
     {
         $method = new Function_($this->fqsen);
         $this->assertEquals(new Mixed_(), $method->getReturnType());
@@ -98,7 +98,7 @@ final class Function_Test extends TestCase
     /**
      * @covers ::getReturnType
      */
-    public function testGetReturnTypeFromConstructor() : void
+    public function testGetReturnTypeFromConstructor(): void
     {
         $returnType = new String_();
         $method = new Function_(
@@ -114,7 +114,7 @@ final class Function_Test extends TestCase
     /**
      * @covers ::getLocation
      */
-    public function testLineNumberIsMinusOneWhenNoneIsProvided() : void
+    public function testLineNumberIsMinusOneWhenNoneIsProvided(): void
     {
         $this->assertSame(-1, $this->fixture->getLocation()->getLineNumber());
         $this->assertSame(0, $this->fixture->getLocation()->getColumnNumber());
@@ -125,7 +125,7 @@ final class Function_Test extends TestCase
      *
      * @covers ::getLocation
      */
-    public function testLineAndColumnNumberIsReturnedWhenALocationIsProvided() : void
+    public function testLineAndColumnNumberIsReturnedWhenALocationIsProvided(): void
     {
         $fixture = new Function_($this->fqsen, $this->docBlock, new Location(100, 20));
 

--- a/tests/unit/phpDocumentor/Reflection/Php/Interface_Test.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Interface_Test.php
@@ -47,7 +47,7 @@ final class Interface_Test extends TestCase
     /**
      * Creates a new (empty) fixture object.
      */
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->exampleParents = [
             new Fqsen('\MySpace\MyParent'),
@@ -62,7 +62,7 @@ final class Interface_Test extends TestCase
     /**
      * @covers ::getName
      */
-    public function testGetName() : void
+    public function testGetName(): void
     {
         $this->assertSame($this->fqsen->getName(), $this->fixture->getName());
     }
@@ -70,7 +70,7 @@ final class Interface_Test extends TestCase
     /**
      * @covers ::getFqsen
      */
-    public function testGetFqsen() : void
+    public function testGetFqsen(): void
     {
         $this->assertSame($this->fqsen, $this->fixture->getFqsen());
     }
@@ -78,7 +78,7 @@ final class Interface_Test extends TestCase
     /**
      * @covers ::getDocBlock
      */
-    public function testGetDocblock() : void
+    public function testGetDocblock(): void
     {
         $this->assertSame($this->docBlock, $this->fixture->getDocBlock());
     }
@@ -87,7 +87,7 @@ final class Interface_Test extends TestCase
      * @covers ::addConstant
      * @covers ::getConstants
      */
-    public function testSettingAndGettingConstants() : void
+    public function testSettingAndGettingConstants(): void
     {
         $this->assertEquals([], $this->fixture->getConstants());
 
@@ -102,7 +102,7 @@ final class Interface_Test extends TestCase
      * @covers ::addMethod
      * @covers ::getMethods
      */
-    public function testSettingAndGettingMethods() : void
+    public function testSettingAndGettingMethods(): void
     {
         $this->assertEquals([], $this->fixture->getMethods());
 
@@ -116,7 +116,7 @@ final class Interface_Test extends TestCase
     /**
      * @covers ::getParents
      */
-    public function testReturningTheParentsOfThisInterface() : void
+    public function testReturningTheParentsOfThisInterface(): void
     {
         $this->assertSame($this->exampleParents, $this->fixture->getParents());
     }
@@ -124,7 +124,7 @@ final class Interface_Test extends TestCase
     /**
      * @covers ::getLocation
      */
-    public function testLineNumberIsMinusOneWhenNoneIsProvided() : void
+    public function testLineNumberIsMinusOneWhenNoneIsProvided(): void
     {
         $this->assertSame(-1, $this->fixture->getLocation()->getLineNumber());
         $this->assertSame(0, $this->fixture->getLocation()->getColumnNumber());
@@ -135,7 +135,7 @@ final class Interface_Test extends TestCase
      *
      * @covers ::getLocation
      */
-    public function testLineAndColumnNumberIsReturnedWhenALocationIsProvided() : void
+    public function testLineAndColumnNumberIsReturnedWhenALocationIsProvided(): void
     {
         $fixture = new Interface_($this->fqsen, [], $this->docBlock, new Location(100, 20));
 
@@ -146,7 +146,7 @@ final class Interface_Test extends TestCase
     /**
      * @covers ::__construct
      */
-    public function testArrayWithParentsMustBeFqsenObjects() : void
+    public function testArrayWithParentsMustBeFqsenObjects(): void
     {
         $this->expectException(InvalidArgumentException::class);
 

--- a/tests/unit/phpDocumentor/Reflection/Php/MethodTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/MethodTest.php
@@ -38,7 +38,7 @@ final class MethodTest extends TestCase
     /** @var DocBlock */
     private $docblock;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->fqsen = new Fqsen('\My\Space::MyMethod()');
         $this->visibility = new Visibility('private');
@@ -49,7 +49,7 @@ final class MethodTest extends TestCase
      * @covers ::getFqsen
      * @covers ::getName
      */
-    public function testGetFqsenAndGetName() : void
+    public function testGetFqsenAndGetName(): void
     {
         $method = new Method($this->fqsen);
 
@@ -60,7 +60,7 @@ final class MethodTest extends TestCase
     /**
      * @covers ::getDocblock
      */
-    public function testGetDocBlock() : void
+    public function testGetDocBlock(): void
     {
         $method = new Method($this->fqsen, $this->visibility, $this->docblock);
 
@@ -73,7 +73,7 @@ final class MethodTest extends TestCase
      * @covers ::getArguments
      * @covers ::addArgument
      */
-    public function testAddingAndGettingArguments() : void
+    public function testAddingAndGettingArguments(): void
     {
         $method = new Method($this->fqsen);
         $this->assertEquals([], $method->getArguments());
@@ -87,7 +87,7 @@ final class MethodTest extends TestCase
     /**
      * @covers ::isAbstract
      */
-    public function testGettingWhetherMethodIsAbstract() : void
+    public function testGettingWhetherMethodIsAbstract(): void
     {
         $method = new Method($this->fqsen, $this->visibility, $this->docblock, false);
         $this->assertFalse($method->isAbstract());
@@ -99,7 +99,7 @@ final class MethodTest extends TestCase
     /**
      * @covers ::isFinal
      */
-    public function testGettingWhetherMethodIsFinal() : void
+    public function testGettingWhetherMethodIsFinal(): void
     {
         $method = new Method($this->fqsen, $this->visibility, $this->docblock, false, false, false);
         $this->assertFalse($method->isFinal());
@@ -111,7 +111,7 @@ final class MethodTest extends TestCase
     /**
      * @covers ::isStatic
      */
-    public function testGettingWhetherMethodIsStatic() : void
+    public function testGettingWhetherMethodIsStatic(): void
     {
         $method = new Method($this->fqsen, $this->visibility, $this->docblock, false, false, false);
         $this->assertFalse($method->isStatic());
@@ -123,7 +123,7 @@ final class MethodTest extends TestCase
     /**
      * @covers ::getVisibility
      */
-    public function testGettingVisibility() : void
+    public function testGettingVisibility(): void
     {
         $method = new Method($this->fqsen, $this->visibility, $this->docblock, false, false, false);
         $this->assertSame($this->visibility, $method->getVisibility());
@@ -132,7 +132,7 @@ final class MethodTest extends TestCase
     /**
      * @covers ::getVisibility
      */
-    public function testGetDefaultVisibility() : void
+    public function testGetDefaultVisibility(): void
     {
         $method = new Method($this->fqsen);
         $this->assertEquals(new Visibility('public'), $method->getVisibility());
@@ -141,7 +141,7 @@ final class MethodTest extends TestCase
     /**
      * @covers ::getReturnType
      */
-    public function testGetDefaultReturnType() : void
+    public function testGetDefaultReturnType(): void
     {
         $method = new Method($this->fqsen);
         $this->assertEquals(new Mixed_(), $method->getReturnType());
@@ -150,7 +150,7 @@ final class MethodTest extends TestCase
     /**
      * @covers ::getReturnType
      */
-    public function testGetReturnTypeFromConstructor() : void
+    public function testGetReturnTypeFromConstructor(): void
     {
         $returnType = new String_();
         $method = new Method(
@@ -170,7 +170,7 @@ final class MethodTest extends TestCase
     /**
      * @covers ::getLocation
      */
-    public function testLineNumberIsMinusOneWhenNoneIsProvided() : void
+    public function testLineNumberIsMinusOneWhenNoneIsProvided(): void
     {
         $fixture = new Method($this->fqsen);
 
@@ -183,7 +183,7 @@ final class MethodTest extends TestCase
      *
      * @covers ::getLocation
      */
-    public function testLineAndColumnNumberIsReturnedWhenALocationIsProvided() : void
+    public function testLineAndColumnNumberIsReturnedWhenALocationIsProvided(): void
     {
         $fixture = new Method($this->fqsen, null, null, false, false, false, new Location(100, 20));
 

--- a/tests/unit/phpDocumentor/Reflection/Php/Namespace_Test.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Namespace_Test.php
@@ -38,7 +38,7 @@ class Namespace_Test extends TestCase
     /**
      * Creates a new (emoty) fixture object.
      */
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->fqsen    = new Fqsen('\MySpace');
         $this->docBlock = new DocBlock('');
@@ -51,7 +51,7 @@ class Namespace_Test extends TestCase
      * @covers ::getClasses
      * @covers ::AddClass
      */
-    public function testAddAndGetClasses() : void
+    public function testAddAndGetClasses(): void
     {
         $this->assertEmpty($this->fixture->getClasses());
 
@@ -66,7 +66,7 @@ class Namespace_Test extends TestCase
      * @covers ::getConstants
      * @covers ::addConstant
      */
-    public function testAddAndGetConstants() : void
+    public function testAddAndGetConstants(): void
     {
         $this->assertEmpty($this->fixture->getConstants());
 
@@ -81,7 +81,7 @@ class Namespace_Test extends TestCase
      * @covers ::getFunctions
      * @covers ::addFunction
      */
-    public function testAddAndGetFunctions() : void
+    public function testAddAndGetFunctions(): void
     {
         $this->assertEmpty($this->fixture->getFunctions());
 
@@ -96,7 +96,7 @@ class Namespace_Test extends TestCase
      * @covers ::getInterfaces
      * @covers ::addInterface
      */
-    public function testAddAndGetInterfaces() : void
+    public function testAddAndGetInterfaces(): void
     {
         $this->assertEmpty($this->fixture->getInterfaces());
 
@@ -111,7 +111,7 @@ class Namespace_Test extends TestCase
      * @covers ::getTraits
      * @covers ::addTrait
      */
-    public function testAddAndGetTraits() : void
+    public function testAddAndGetTraits(): void
     {
         $this->assertEmpty($this->fixture->getTraits());
 
@@ -126,7 +126,7 @@ class Namespace_Test extends TestCase
      * @covers ::getFqsen
      * @covers ::getName
      */
-    public function testGetFqsen() : void
+    public function testGetFqsen(): void
     {
         $this->assertSame($this->fqsen, $this->fixture->getFqsen());
         $this->assertEquals($this->fqsen->getName(), $this->fixture->getName());

--- a/tests/unit/phpDocumentor/Reflection/Php/NodesFactoryTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/NodesFactoryTest.php
@@ -36,7 +36,7 @@ final class NodesFactoryTest extends TestCase
      *
      * @covers ::createInstance
      */
-    public function testThatAFactoryWithRecommendedComponentsCanBeInstantiated() : void
+    public function testThatAFactoryWithRecommendedComponentsCanBeInstantiated(): void
     {
         $factory = NodesFactory::createInstance();
 
@@ -47,7 +47,7 @@ final class NodesFactoryTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testThatCodeGetsConvertedIntoNodes() : void
+    public function testThatCodeGetsConvertedIntoNodes(): void
     {
         $parser = $this->prophesize(Parser::class);
         $parser->parse('this is my code')->willReturn(['parsed code']);
@@ -62,7 +62,7 @@ final class NodesFactoryTest extends TestCase
         $this->assertSame(['traversed code'], $result);
     }
 
-    private function givenTheExpectedDefaultNodesFactory() : NodesFactory
+    private function givenTheExpectedDefaultNodesFactory(): NodesFactory
     {
         $parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
         $traverser = new NodeTraverser();

--- a/tests/unit/phpDocumentor/Reflection/Php/ProjectFactoryStrategiesTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/ProjectFactoryStrategiesTest.php
@@ -31,7 +31,7 @@ class ProjectFactoryStrategiesTest extends TestCase
     /**
      * @covers ::addStrategy
      */
-    public function testStrategiesAreChecked() : void
+    public function testStrategiesAreChecked(): void
     {
         new ProjectFactoryStrategies([new DummyFactoryStrategy()]);
         $this->assertTrue(true);
@@ -41,7 +41,7 @@ class ProjectFactoryStrategiesTest extends TestCase
      * @covers ::findMatching
      * @covers ::addStrategy
      */
-    public function testFindMatching() : void
+    public function testFindMatching(): void
     {
         $strategy  = new DummyFactoryStrategy();
         $container = new ProjectFactoryStrategies([$strategy]);
@@ -56,7 +56,7 @@ class ProjectFactoryStrategiesTest extends TestCase
     /**
      * @covers ::findMatching
      */
-    public function testCreateThrowsExceptionWhenStrategyNotFound() : void
+    public function testCreateThrowsExceptionWhenStrategyNotFound(): void
     {
         $this->expectException('OutOfBoundsException');
         $container = new ProjectFactoryStrategies([]);

--- a/tests/unit/phpDocumentor/Reflection/Php/ProjectFactoryTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/ProjectFactoryTest.php
@@ -19,6 +19,7 @@ use phpDocumentor\Reflection\File\LocalFile;
 use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Php\Factory\ContextStack;
 use Prophecy\Argument as ProphesizeArgument;
+
 use function array_keys;
 use function assert;
 use function current;

--- a/tests/unit/phpDocumentor/Reflection/Php/ProjectFactoryTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/ProjectFactoryTest.php
@@ -68,7 +68,7 @@ final class ProjectFactoryTest extends MockeryTestCase
      *
      * @covers ::createInstance
      */
-    public function testCreatingAnInstanceInstantiatesItWithTheRecommendedStrategies() : void
+    public function testCreatingAnInstanceInstantiatesItWithTheRecommendedStrategies(): void
     {
         $this->assertInstanceOf(ProjectFactory::class, ProjectFactory::createInstance());
     }
@@ -76,7 +76,7 @@ final class ProjectFactoryTest extends MockeryTestCase
     /**
      * @covers ::create
      */
-    public function testCreate() : void
+    public function testCreate(): void
     {
         $expected = ['some/file.php', 'some/other.php'];
         $calls = 0;
@@ -102,7 +102,7 @@ final class ProjectFactoryTest extends MockeryTestCase
             ProphesizeArgument::type(ContextStack::class),
             ProphesizeArgument::type(LocalFile::class),
             ProphesizeArgument::any()
-        )->will(function ($args) use (&$calls, $expected) : void {
+        )->will(function ($args) use (&$calls, $expected): void {
             $context = $args[0];
             assert($context instanceof ContextStack);
 
@@ -125,7 +125,7 @@ final class ProjectFactoryTest extends MockeryTestCase
     /**
      * @covers ::create
      */
-    public function testCreateThrowsExceptionWhenStrategyNotFound() : void
+    public function testCreateThrowsExceptionWhenStrategyNotFound(): void
     {
         $this->expectException('OutOfBoundsException');
         $projectFactory = new ProjectFactory([]);
@@ -135,7 +135,7 @@ final class ProjectFactoryTest extends MockeryTestCase
     /**
      * @covers ::create
      */
-    public function testCreateProjectFromFileWithNamespacedClass() : void
+    public function testCreateProjectFromFileWithNamespacedClass(): void
     {
         $file = new File(md5('some/file.php'), 'some/file.php');
         $file->addNamespace(new Fqsen('\mySpace'));
@@ -154,7 +154,7 @@ final class ProjectFactoryTest extends MockeryTestCase
     /**
      * @covers ::create
      */
-    public function testWithNamespacedInterface() : void
+    public function testWithNamespacedInterface(): void
     {
         $file = new File(md5('some/file.php'), 'some/file.php');
         $file->addNamespace(new Fqsen('\mySpace'));
@@ -171,7 +171,7 @@ final class ProjectFactoryTest extends MockeryTestCase
     /**
      * @covers ::create
      */
-    public function testWithNamespacedFunction() : void
+    public function testWithNamespacedFunction(): void
     {
         $file = new File(md5('some/file.php'), 'some/file.php');
         $file->addNamespace(new Fqsen('\mySpace'));
@@ -188,7 +188,7 @@ final class ProjectFactoryTest extends MockeryTestCase
     /**
      * @covers ::create
      */
-    public function testWithNamespacedConstant() : void
+    public function testWithNamespacedConstant(): void
     {
         $file = new File(md5('some/file.php'), 'some/file.php');
         $file->addNamespace(new Fqsen('\mySpace'));
@@ -205,7 +205,7 @@ final class ProjectFactoryTest extends MockeryTestCase
     /**
      * @covers ::create
      */
-    public function testWithNamespacedTrait() : void
+    public function testWithNamespacedTrait(): void
     {
         $file = new File(md5('some/file.php'), 'some/file.php');
         $file->addNamespace(new Fqsen('\mySpace'));
@@ -222,7 +222,7 @@ final class ProjectFactoryTest extends MockeryTestCase
     /**
      * @covers ::create
      */
-    public function testNamespaceSpreadOverMultipleFiles() : void
+    public function testNamespaceSpreadOverMultipleFiles(): void
     {
         $someFile = new File(md5('some/file.php'), 'some/file.php');
         $someFile->addNamespace(new Fqsen('\mySpace'));
@@ -241,7 +241,7 @@ final class ProjectFactoryTest extends MockeryTestCase
     /**
      * @covers ::create
      */
-    public function testSingleFileMultipleNamespaces() : void
+    public function testSingleFileMultipleNamespaces(): void
     {
         $someFile = new File(md5('some/file.php'), 'some/file.php');
         $someFile->addNamespace(new Fqsen('\mySpace'));
@@ -265,7 +265,7 @@ final class ProjectFactoryTest extends MockeryTestCase
      *
      * @throws Exception
      */
-    private function fetchNamespacesFromSingleFile(File $file) : array
+    private function fetchNamespacesFromSingleFile(File $file): array
     {
         return $this->fetchNamespacesFromMultipleFiles([$file]);
     }
@@ -279,7 +279,7 @@ final class ProjectFactoryTest extends MockeryTestCase
      *
      * @throws Exception
      */
-    private function fetchNamespacesFromMultipleFiles(array $files) : array
+    private function fetchNamespacesFromMultipleFiles(array $files): array
     {
         $fileStrategyMock = $this->prophesize(ProjectFactoryStrategy::class);
         $fileStrategyMock->matches(
@@ -291,7 +291,7 @@ final class ProjectFactoryTest extends MockeryTestCase
             ProphesizeArgument::type(ContextStack::class),
             ProphesizeArgument::type(File::class),
             ProphesizeArgument::any()
-        )->will(function ($args) : void {
+        )->will(function ($args): void {
             $context = $args[0];
             assert($context instanceof ContextStack);
 

--- a/tests/unit/phpDocumentor/Reflection/Php/ProjectTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/ProjectTest.php
@@ -33,7 +33,7 @@ class ProjectTest extends TestCase
     /**
      * Initializes the fixture object.
      */
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->fixture = new Project(self::EXAMPLE_NAME);
     }
@@ -43,7 +43,7 @@ class ProjectTest extends TestCase
      *
      * @covers ::getName
      */
-    public function testGetSetName() : void
+    public function testGetSetName(): void
     {
         $this->assertEquals(self::EXAMPLE_NAME, $this->fixture->getName());
     }
@@ -55,7 +55,7 @@ class ProjectTest extends TestCase
      * @covers ::getFiles
      * @covers ::addFile
      */
-    public function testGetAddFiles() : void
+    public function testGetAddFiles(): void
     {
         $this->assertEmpty($this->fixture->getFiles());
 
@@ -70,7 +70,7 @@ class ProjectTest extends TestCase
      *
      * @covers ::getRootNamespace
      */
-    public function testGetRootNamespace() : void
+    public function testGetRootNamespace(): void
     {
         $this->assertInstanceOf(Namespace_::class, $this->fixture->getRootNamespace());
 
@@ -86,7 +86,7 @@ class ProjectTest extends TestCase
      * @covers ::getNamespaces
      * @covers ::addNamespace
      */
-    public function testGetAddNamespace() : void
+    public function testGetAddNamespace(): void
     {
         $this->assertEmpty($this->fixture->getNamespaces());
 

--- a/tests/unit/phpDocumentor/Reflection/Php/PropertyTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/PropertyTest.php
@@ -37,7 +37,7 @@ final class PropertyTest extends TestCase
     /** @var DocBlock */
     private $docBlock;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->fqsen = new Fqsen('\My\Class::$property');
         $this->visibility = new Visibility('private');
@@ -50,7 +50,7 @@ final class PropertyTest extends TestCase
      * @covers ::getFqsen
      * @covers ::getName
      */
-    public function testGetFqsenAndGetName() : void
+    public function testGetFqsenAndGetName(): void
     {
         $property = new Property($this->fqsen);
 
@@ -64,7 +64,7 @@ final class PropertyTest extends TestCase
      * @covers ::isStatic
      * @covers ::__construct
      */
-    public function testGettingWhetherPropertyIsStatic() : void
+    public function testGettingWhetherPropertyIsStatic(): void
     {
         $property = new Property($this->fqsen, $this->visibility, $this->docBlock, null, false);
         $this->assertFalse($property->isStatic());
@@ -79,7 +79,7 @@ final class PropertyTest extends TestCase
      * @covers ::getVisibility
      * @covers ::__construct
      */
-    public function testGettingVisibility() : void
+    public function testGettingVisibility(): void
     {
         $property = new Property($this->fqsen, $this->visibility, $this->docBlock, null, true);
 
@@ -92,7 +92,7 @@ final class PropertyTest extends TestCase
      * @covers ::getTypes
      * @covers ::addType
      */
-    public function testSetAndGetTypes() : void
+    public function testSetAndGetTypes(): void
     {
         $property = new Property($this->fqsen, $this->visibility, $this->docBlock, null, true);
         $this->assertEquals([], $property->getTypes());
@@ -106,7 +106,7 @@ final class PropertyTest extends TestCase
      *
      * @covers ::getDefault
      */
-    public function testGetDefault() : void
+    public function testGetDefault(): void
     {
         $property = new Property($this->fqsen, $this->visibility, $this->docBlock, null, false);
         $this->assertNull($property->getDefault());
@@ -120,7 +120,7 @@ final class PropertyTest extends TestCase
      *
      * @covers ::getDocBlock
      */
-    public function testGetDocBlock() : void
+    public function testGetDocBlock(): void
     {
         $property = new Property($this->fqsen, $this->visibility, $this->docBlock, null, false);
         $this->assertSame($this->docBlock, $property->getDocBlock());
@@ -131,7 +131,7 @@ final class PropertyTest extends TestCase
      *
      * @covers ::getLocation
      */
-    public function testLineNumberIsMinusOneWhenNoneIsProvided() : void
+    public function testLineNumberIsMinusOneWhenNoneIsProvided(): void
     {
         $fixture = new Property($this->fqsen);
 
@@ -145,7 +145,7 @@ final class PropertyTest extends TestCase
      *
      * @covers ::getLocation
      */
-    public function testLineAndColumnNumberIsReturnedWhenALocationIsProvided() : void
+    public function testLineAndColumnNumberIsReturnedWhenALocationIsProvided(): void
     {
         $fixture = new Property($this->fqsen, null, null, null, false, new Location(100, 20));
 
@@ -159,7 +159,7 @@ final class PropertyTest extends TestCase
      *
      * @covers ::getType
      */
-    public function testGetType() : void
+    public function testGetType(): void
     {
         $type = new Integer();
         $fixture = new Property(

--- a/tests/unit/phpDocumentor/Reflection/Php/Trait_Test.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Trait_Test.php
@@ -37,7 +37,7 @@ final class Trait_Test extends MockeryTestCase
     /**
      * Creates a new (empty) fixture object.
      */
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->fqsen = new Fqsen('\MyTrait');
         $this->docBlock = new DocBlock('');
@@ -48,7 +48,7 @@ final class Trait_Test extends MockeryTestCase
      * @covers ::getFqsen
      * @covers ::getName
      */
-    public function testGetFqsenAndGetName() : void
+    public function testGetFqsenAndGetName(): void
     {
         $this->assertSame($this->fqsen, $this->fixture->getFqsen());
         $this->assertEquals($this->fqsen->getName(), $this->fixture->getName());
@@ -61,7 +61,7 @@ final class Trait_Test extends MockeryTestCase
      * @covers ::addProperty
      * @covers ::getProperties
      */
-    public function testAddAndGettingProperties() : void
+    public function testAddAndGettingProperties(): void
     {
         $this->assertEquals([], $this->fixture->getProperties());
 
@@ -79,7 +79,7 @@ final class Trait_Test extends MockeryTestCase
      * @covers ::addMethod
      * @covers ::getMethods
      */
-    public function testAddAndGettingMethods() : void
+    public function testAddAndGettingMethods(): void
     {
         $this->assertEquals([], $this->fixture->getMethods());
 
@@ -94,7 +94,7 @@ final class Trait_Test extends MockeryTestCase
      * @covers ::getUsedTraits
      * @covers ::AddUsedTrait
      */
-    public function testAddAndGettingUsedTrait() : void
+    public function testAddAndGettingUsedTrait(): void
     {
         $this->assertEmpty($this->fixture->getUsedTraits());
 
@@ -108,7 +108,7 @@ final class Trait_Test extends MockeryTestCase
     /**
      * @covers ::getDocBlock
      */
-    public function testGetDocblock() : void
+    public function testGetDocblock(): void
     {
         $this->assertSame($this->docBlock, $this->fixture->getDocBlock());
     }
@@ -116,7 +116,7 @@ final class Trait_Test extends MockeryTestCase
     /**
      * @covers ::getLocation
      */
-    public function testLineNumberIsMinusOneWhenNoneIsProvided() : void
+    public function testLineNumberIsMinusOneWhenNoneIsProvided(): void
     {
         $this->assertSame(-1, $this->fixture->getLocation()->getLineNumber());
         $this->assertSame(0, $this->fixture->getLocation()->getColumnNumber());
@@ -127,7 +127,7 @@ final class Trait_Test extends MockeryTestCase
      *
      * @covers ::getLocation
      */
-    public function testLineAndColumnNumberIsReturnedWhenALocationIsProvided() : void
+    public function testLineAndColumnNumberIsReturnedWhenALocationIsProvided(): void
     {
         $fixture = new Trait_($this->fqsen, $this->docBlock, new Location(100, 20));
 

--- a/tests/unit/phpDocumentor/Reflection/Php/VisibilityTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/VisibilityTest.php
@@ -27,7 +27,7 @@ class VisibilityTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testVisibility(string $input, string $expected) : void
+    public function testVisibility(string $input, string $expected): void
     {
         $visibility = new Visibility($input);
 
@@ -37,7 +37,7 @@ class VisibilityTest extends TestCase
     /**
      * @return string[][]
      */
-    public function visibilityProvider() : array
+    public function visibilityProvider(): array
     {
         return [
             ['public', 'public'],
@@ -50,7 +50,7 @@ class VisibilityTest extends TestCase
     /**
      * @covers ::__construct
      */
-    public function testVisibilityChecksInput() : void
+    public function testVisibilityChecksInput(): void
     {
         $this->expectException('InvalidArgumentException');
         new Visibility('fooBar');

--- a/tests/unit/phpDocumentor/Reflection/Types/NamespaceNodeToContextTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Types/NamespaceNodeToContextTest.php
@@ -23,7 +23,7 @@ final class NamespaceNodeToContextTest extends TestCase
      * @dataProvider expectedContextsProvider
      * @covers ::__invoke
      */
-    public function testConversion(?Namespace_ $namespace, Context $expectedContext) : void
+    public function testConversion(?Namespace_ $namespace, Context $expectedContext): void
     {
         $this->assertEquals($expectedContext, (new NamespaceNodeToContext())->__invoke($namespace));
     }
@@ -31,7 +31,7 @@ final class NamespaceNodeToContextTest extends TestCase
     /**
      * @return (Namespace|Context|null)[][]
      */
-    public function expectedContextsProvider() : array
+    public function expectedContextsProvider(): array
     {
         $namespaceWithImports = new Namespace_(
             new Name('With\\Imports'),


### PR DESCRIPTION
### PHPCS ruleset: update ruleset for upstream changes

* Fix the name and description to prevent confusion between the project ruleset and the organisation ruleset.
* Set the minimum PHP version for the PHPCompatibility standard.
* Don't require property type declarations.
* Ensure special characters used as literals in an exclude pattern are escaped.

### CS: no whitespace before return type colon

### CS: blank line between different use statement types

### CS: miscellaneous other whitespace fixes 