### PR TITLE
GH Actions: turn on tests against PHP 8.1 & various other tweaks

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -54,6 +54,7 @@ jobs:
     name: Unit tests for PHP version ${{ matrix.php-versions }} on ${{ matrix.operating-system }}
     runs-on: ${{ matrix.operating-system }}
     strategy:
+      fail-fast: false
       matrix:
         operating-system:
           - ubuntu-latest
@@ -110,7 +111,6 @@ jobs:
           composer-options: --optimize-autoloader
 
       - name: Run PHPUnit
-        continue-on-error: true
         run: php tools/phpunit
 
   codestyle:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -104,19 +104,10 @@ jobs:
           GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: phive --no-progress install --copy --trust-gpg-keys ${{ env.phiveGPGKeys }} phpunit:^8.5
 
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Cache dependencies
-        uses: actions/cache@v2.1.6
+      - name: Install Composer dependencies & cache dependencies
+        uses: "ramsey/composer-install@v1"
         with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
-
-      - name: Install dependencies
-        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+          composer-options: --optimize-autoloader
 
       - name: Run PHPUnit
         continue-on-error: true
@@ -200,19 +191,10 @@ jobs:
 #          tools: psalm
 #          ini-values: memory_limit=2G, display_errors=On, error_reporting=-1
 #
-#      - name: Get composer cache directory
-#        id: composer-cache
-#        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-#
-#      - name: Cache dependencies
-#        uses: actions/cache@v2.1.6
+#      - name: Install Composer dependencies & cache dependencies
+#        uses: "ramsey/composer-install@v1"
 #        with:
-#          path: ${{ steps.composer-cache.outputs.dir }}
-#          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-#          restore-keys: ${{ runner.os }}-composer-
-#
-#      - name: Install dependencies
-#        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+#          composer-options: --optimize-autoloader
 #
 #      - name: Run psalm
 #        run: psalm --output-format=github

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -60,7 +60,8 @@ jobs:
           - ubuntu-latest
           - windows-latest
           - macOS-latest
-        php-versions: ['7.2', '7.3', '7.4', '8.0']
+        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1']
+
     env:
       extensions: mbstring
       key: cache-v1 # can be any string, change to clear the extension cache.

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,6 +3,8 @@ on:
     branches:
       - 5.x
   pull_request:
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
 name: Qa workflow
 env:
   phiveGPGKeys: 4AA394086372C20A,D2CCAC42F6295E7D,E82B2FB314E9906E,8A03EA3B385DBAA1,D0254321FB74703A

--- a/phive.xml
+++ b/phive.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="phpunit" version="^9.2" installed="9.4.2" location="./tools/phpunit" copy="true"/>
+  <phar name="phpunit" version="^9.5" installed="9.5.8" location="./tools/phpunit" copy="true"/>
   <phar name="phpbench" version="^0.16.9" installed="0.16.9" location="./tools/phpbench" copy="true"/>
   <phar name="scrutinizer-ci/ocular" version="^1.6.0" installed="1.6.0" location="./tools/ocular" copy="true" force-accept-unsigned="true"/>
 </phive>


### PR DESCRIPTION
TL;DR: these are largely the same CI changes which I made, and which have been merged, in the other repos.
As I cloned this repo now for the CS update anyway, figured I may as well bring the CI in line as well.

The build will fail until PR #209 has been merged, but should pass without issue after that.


## Commit details

### GH Actions: allow for manually triggering a workflow

Triggering a workflow for a branch manually is not supported by default in GH Actions, but has to be explicitly allowed.

This is useful if, for instance, an external action script or composer dependency has broken.
Once a fix is available, failing builds for open PRs can be retriggered manually instead of having to be re-pushed to retrigger the workflow.

Ref: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/

### GH Actions: simplify Composer caching

... by using the `ramsey/composer-install` action.

Ref: https://github.com/marketplace/actions/install-composer-dependencies

### GH Actions: fail the build if a test run fails

The way things were set up now in the `phpunit` job, no matter whether tests passed or failed, the workflow would always continue.

I suspect this may have been set-up this way to make sure that all variations of test runs will actually be run ?
The downside is that, while you will see a ❌ for the individual build, the workflow will not be marked as failed if a test runs fails.

I'm proposing to change this now by:
* Removing the `continue-on-error` for the test run.
* Adding the `fail-fast` key and setting it to `false`.
    By default this key is set to `true`, which means that if any individual build within the job fails, all other builds within the job will be cancelled.
    By setting it to `false`, all builds in the matrix will still be run, but if any of them fail, the workflow will be marked as "failed".

### Phive: upgrade used version of PHPUnit

### GH Actions: start testing against PHP 8.1

As the tests currently pass, I see no reason to allow them to fail.

