### PR TITLE
GH Actions: version update for `ramsey/composer-install`

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -107,7 +107,7 @@ jobs:
         run: phive --no-progress install --copy --trust-gpg-keys ${{ env.phiveGPGKeys }} phpunit:^8.5
 
       - name: Install Composer dependencies & cache dependencies
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
         with:
           composer-options: --optimize-autoloader
 
@@ -193,7 +193,7 @@ jobs:
 #          ini-values: memory_limit=2G, display_errors=On, error_reporting=-1
 #
 #      - name: Install Composer dependencies & cache dependencies
-#        uses: "ramsey/composer-install@v1"
+#        uses: "ramsey/composer-install@v2"
 #        with:
 #          composer-options: --optimize-autoloader
 #


### PR DESCRIPTION
The action used to install Composer packages and handle the caching has released a new major (and some follow-up patch releases), which means, the action reference needs to be updated to benefit from it.

Refs:
* https://github.com/ramsey/composer-install/releases/tag/2.0.0
* https://github.com/ramsey/composer-install/releases/tag/2.0.1
* https://github.com/ramsey/composer-install/releases/tag/2.0.2