### PR TITLE
Fix #233 inline defined const

### DIFF
--- a/src/phpDocumentor/Reflection/Php/Factory/ContextStack.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/ContextStack.php
@@ -10,6 +10,7 @@ use phpDocumentor\Reflection\Php\File as FileElement;
 use phpDocumentor\Reflection\Php\Project;
 use phpDocumentor\Reflection\Types\Context as TypeContext;
 
+use function array_reverse;
 use function end;
 
 final class ContextStack
@@ -72,5 +73,27 @@ final class ContextStack
         }
 
         return $element;
+    }
+
+    /**
+     * Returns the first element of type.
+     *
+     * Will reverse search the stack for an element matching $type. Will return null when the element type is not
+     * in the current stack.
+     *
+     * @param class-string $type
+     *
+     * @return Element|FileElement|null
+     */
+    public function search(string $type)
+    {
+        $reverseElements = array_reverse($this->elements);
+        foreach ($reverseElements as $element) {
+            if ($element instanceof $type) {
+                return $element;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/phpDocumentor/Reflection/Php/Factory/Define.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Define.php
@@ -99,7 +99,7 @@ final class Define extends AbstractFactory
             return;
         }
 
-        $file = $context->peek();
+        $file = $context->search(FileElement::class);
         assert($file instanceof FileElement);
 
         $constant = new ConstantElement(

--- a/tests/integration/data/Luigi/constants.php
+++ b/tests/integration/data/Luigi/constants.php
@@ -5,3 +5,7 @@ namespace Luigi;
 const OVEN_TEMPERATURE = 9001;
 define('\\Luigi\\MAX_OVEN_TEMPERATURE', 9002);
 define('OUTSIDE_OVEN_TEMPERATURE', 9002);
+
+function in_function_define(){
+    define('IN_FUNCTION_OVEN_TEMPERATURE', 9003);
+}

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/ContextStackTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/ContextStackTest.php
@@ -7,6 +7,7 @@ namespace phpDocumentor\Reflection\Php\Factory;
 use OutOfBoundsException;
 use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Php\Class_ as ClassElement;
+use phpDocumentor\Reflection\Php\Method;
 use phpDocumentor\Reflection\Php\Project;
 use phpDocumentor\Reflection\Types\Context;
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
@@ -88,5 +89,34 @@ final class ContextStackTest extends PHPUnitTestCase
         self::assertSame($class, $context->peek());
         self::assertSame($project, $context->getProject());
         self::assertSame($typeContext, $context->getTypeContext());
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::search
+     */
+    public function testSearchEmptyStackResultsInNull(): void
+    {
+        $project = new Project('myProject');
+        $context = new ContextStack($project);
+
+        self::assertNull($context->search(ClassElement::class));
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::search
+     */
+    public function testSearchStackForExistingElementTypeWillReturnTheFirstHit(): void
+    {
+        $class = new ClassElement(new Fqsen('\MyClass'));
+        $project = new Project('myProject');
+        $context = new ContextStack($project);
+        $context = $context
+            ->push(new ClassElement(new Fqsen('\OtherClass')))
+            ->push($class)
+            ->push(new Method(new Fqsen('\MyClass::method()')));
+
+        self::assertSame($class, $context->search(ClassElement::class));
     }
 }


### PR DESCRIPTION
Defines in a method or function are allowed in PHP. However, they are added
to the global scope. As this library now processes the full method body to be
able to add more information into the reflected code, this caused issues.

As the defines are added to the global scope of the execution they are basically
defined at a file-level when a define was executed. This is the best we can get right now to
reflect what the application would do at runtime.

Fixes #233 