### PR TITLE
GH Actions: version update for various predefined actions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,7 +12,7 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: composer
         uses: docker://composer
@@ -33,7 +33,7 @@ jobs:
     name: Unit tests
     needs: setup
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: composer
         uses: docker://composer
@@ -71,7 +71,7 @@ jobs:
       - phpunit-with-coverage
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup cache environment
         id: cache-env
@@ -118,7 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [setup, phpunit]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Restore/cache vendor folder
         uses: actions/cache@v2.1.7
         with:
@@ -136,7 +136,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [setup, phpunit]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: composer
         uses: docker://composer
         env:
@@ -168,7 +168,7 @@ jobs:
 #      - phpunit
 #
 #    steps:
-#      - uses: actions/checkout@v2
+#      - uses: actions/checkout@v3
 #
 #      - name: Setup cache environment
 #        id: cache-env
@@ -206,7 +206,7 @@ jobs:
 #    runs-on: ubuntu-latest
 #    needs: [setup, phpunit]
 #    steps:
-#      - uses: actions/checkout@v2
+#      - uses: actions/checkout@v3
 #      - name: fetch tags
 #        run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 #      - name: BC Check


### PR DESCRIPTION
A number of predefined actions have had major release, which warrant an update to the workflow(s).

These updates don't actually contain any changed functionality, they are mostly just a change of the Node version used by the action itself (from Node 14 to Node 16).

Refs:
* https://github.com/actions/checkout/releases