### PR TITLE
Add support for constants in enums

### DIFF
--- a/src/phpDocumentor/Reflection/Php/Enum_.php
+++ b/src/phpDocumentor/Reflection/Php/Enum_.php
@@ -42,6 +42,9 @@ final class Enum_ implements Element, MetaDataContainerInterface
     /** @var array<string, Fqsen> */
     private $implements = [];
 
+    /** @var Constant[] References to constants defined in this enum. */
+    private $constants = [];
+
     /** @var array<string, Method> */
     private $methods = [];
 
@@ -125,6 +128,24 @@ final class Enum_ implements Element, MetaDataContainerInterface
     public function addInterface(Fqsen $interface): void
     {
         $this->implements[(string) $interface] = $interface;
+    }
+
+    /**
+     * Returns the constants of this enum.
+     *
+     * @return Constant[]
+     */
+    public function getConstants(): array
+    {
+        return $this->constants;
+    }
+
+    /**
+     * Add Constant to this enum.
+     */
+    public function addConstant(Constant $constant): void
+    {
+        $this->constants[(string) $constant->getFqsen()] = $constant;
     }
 
     /**

--- a/src/phpDocumentor/Reflection/Php/Factory/ClassConstant.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/ClassConstant.php
@@ -17,6 +17,7 @@ use phpDocumentor\Reflection\DocBlockFactoryInterface;
 use phpDocumentor\Reflection\Location;
 use phpDocumentor\Reflection\Php\Class_;
 use phpDocumentor\Reflection\Php\Constant as ConstantElement;
+use phpDocumentor\Reflection\Php\Enum_;
 use phpDocumentor\Reflection\Php\Interface_;
 use phpDocumentor\Reflection\Php\StrategyContainer;
 use phpDocumentor\Reflection\Php\Visibility;
@@ -66,6 +67,7 @@ final class ClassConstant extends AbstractFactory
             $constantContainer,
             [
                 Class_::class,
+                Enum_::class,
                 Interface_::class,
             ]
         );

--- a/tests/integration/EnumTest.php
+++ b/tests/integration/EnumTest.php
@@ -20,6 +20,7 @@ final class EnumTest extends TestCase
 {
     const FILE = __DIR__ . '/data/Enums/base.php';
     const BACKED_ENUM = __DIR__ . '/data/Enums/backedEnum.php';
+    const ENUM_WITH_CONSTANT = __DIR__ . '/data/Enums/enumWithConstant.php';
     const ENUM_CONSUMER = __DIR__ . '/data/Enums/EnumConsumer.php';
 
     /** @var ProjectFactory */
@@ -36,6 +37,7 @@ final class EnumTest extends TestCase
             [
                 new LocalFile(self::FILE),
                 new LocalFile(self::BACKED_ENUM),
+                new LocalFile(self::ENUM_WITH_CONSTANT),
                 new LocalFile(self::ENUM_CONSUMER),
             ]
         );
@@ -51,6 +53,17 @@ final class EnumTest extends TestCase
         self::assertNull($enum->getBackedType());
         self::assertArrayHasKey('\MyNamespace\MyEnum::VALUE1', $enum->getCases());
         self::assertArrayHasKey('\MyNamespace\MyEnum::VALUE2', $enum->getCases());
+    }
+
+    public function testEnumWithConstant(): void
+    {
+        $file = $this->project->getFiles()[self::ENUM_WITH_CONSTANT];
+
+        $enum = $file->getEnums()['\MyNamespace\MyEnumWithConstant'];
+        self::assertInstanceOf(Enum_::class, $enum);
+        self::assertCount(1, $enum->getConstants());
+        self::assertArrayHasKey('\MyNamespace\MyEnumWithConstant::MYCONST', $enum->getConstants());
+        self::assertSame("'MyConstValue'", $enum->getConstants()['\MyNamespace\MyEnumWithConstant::MYCONST']->getValue());
     }
 
     public function testBackedEnum(): void

--- a/tests/integration/data/Enums/enumWithConstant.php
+++ b/tests/integration/data/Enums/enumWithConstant.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyNamespace;
+
+enum MyEnumWithConstant
+{
+    public const MYCONST = 'MyConstValue';
+}

--- a/tests/unit/phpDocumentor/Reflection/Php/Enum_Test.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Enum_Test.php
@@ -107,6 +107,21 @@ final class Enum_Test extends TestCase
     }
 
     /**
+     * @covers ::addConstant
+     * @covers ::getConstants
+     */
+    public function testAddAndGettingConstants(): void
+    {
+        $this->assertEmpty($this->fixture->getConstants());
+
+        $constant = new Constant(new Fqsen('\MyClass::MYCONST'));
+
+        $this->fixture->addConstant($constant);
+
+        $this->assertSame(['\MyClass::MYCONST' => $constant], $this->fixture->getConstants());
+    }
+
+    /**
      * @covers ::addMethod
      * @covers ::getMethods
      */


### PR DESCRIPTION
Fixes phpDocumentor/phpDocumentor#3291.

Enumerations may include constants
(see https://www.php.net/manual/en/language.enumerations.constants.php).