### PR TITLE
Add support for using traits in enums

### DIFF
--- a/src/phpDocumentor/Reflection/Php/Factory/TraitUse.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/TraitUse.php
@@ -7,6 +7,7 @@ namespace phpDocumentor\Reflection\Php\Factory;
 use InvalidArgumentException;
 use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Php\Class_;
+use phpDocumentor\Reflection\Php\Enum_;
 use phpDocumentor\Reflection\Php\ProjectFactoryStrategy;
 use phpDocumentor\Reflection\Php\StrategyContainer;
 use phpDocumentor\Reflection\Php\Trait_;
@@ -31,8 +32,12 @@ final class TraitUse implements ProjectFactoryStrategy
 
         $class = $context->peek();
 
-        if ($class instanceof Class_ === false && $class instanceof Trait_ === false) {
-            throw new InvalidArgumentException('Traits can only be used in class or trait');
+        if (
+            $class instanceof Class_ === false
+            && $class instanceof Trait_ === false
+            && $class instanceof Enum_ === false
+        ) {
+            throw new InvalidArgumentException('Traits can only be used in classes, enums or other traits');
         }
 
         foreach ($object->traits as $trait) {

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/TraitUseTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/TraitUseTest.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use phpDocumentor\Reflection\Element;
 use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Php\Class_ as Class_Element;
+use phpDocumentor\Reflection\Php\Enum_ as Enum_Element;
 use phpDocumentor\Reflection\Php\Interface_;
 use phpDocumentor\Reflection\Php\ProjectFactoryStrategies;
 use phpDocumentor\Reflection\Php\Trait_ as Trait_Element;
@@ -26,6 +27,7 @@ final class TraitUseTest extends TestCase
         return [
             [new Class_Element(new Fqsen('\MyClass'))],
             [new Trait_Element(new Fqsen('\MyTrait'))],
+            [new Enum_Element(new Fqsen('\MyEnum'), null)],
         ];
     }
 


### PR DESCRIPTION
Although the basic architecture is present in the Enum type, the TraitUse strategy validates that only a class or other trait could have a trait. I have expanded the validation to include enums.