### PR TITLE
Properties declared in one statement captured default from first

### DIFF
--- a/src/phpDocumentor/Reflection/Php/Factory/Property.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Property.php
@@ -72,13 +72,13 @@ final class Property extends AbstractFactory implements ProjectFactoryStrategy
             ]
         );
 
-        $default = null;
         $iterator = new PropertyIterator($object);
-        if ($iterator->getDefault() !== null) {
-            $default = $this->valueConverter->prettyPrintExpr($iterator->getDefault());
-        }
-
         foreach ($iterator as $stmt) {
+            $default = null;
+            if ($iterator->getDefault() !== null) {
+                $default = $this->valueConverter->prettyPrintExpr($iterator->getDefault());
+            }
+
             $propertyContainer->addProperty(
                 new PropertyDescriptor(
                     $stmt->getFqsen(),


### PR DESCRIPTION
In a properties block where multiple properties have default values, only the first one was taken and applied to each. This change fixes that and introduces a test that verifies this behaviour and as an added benefit, tests the multiple properties in one block behaviour.

Part of the fix for https://github.com/phpDocumentor/phpDocumentor/issues/3334