### PR TITLE
Constants in traits cannot be parsed

### DIFF
--- a/src/phpDocumentor/Reflection/Php/Factory/ClassConstant.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/ClassConstant.php
@@ -20,6 +20,7 @@ use phpDocumentor\Reflection\Php\Constant as ConstantElement;
 use phpDocumentor\Reflection\Php\Enum_;
 use phpDocumentor\Reflection\Php\Interface_;
 use phpDocumentor\Reflection\Php\StrategyContainer;
+use phpDocumentor\Reflection\Php\Trait_;
 use phpDocumentor\Reflection\Php\Visibility;
 use PhpParser\Node\Stmt\ClassConst;
 use PhpParser\PrettyPrinter\Standard as PrettyPrinter;


### PR DESCRIPTION
The validation in the construction of constants checked for the Trait factory and not for the Trait AST node. This meant that for traits it can never parse.

This fix is needed to complete https://github.com/phpDocumentor/phpDocumentor/pull/3394