### PR TITLE
Started reworking expression strings into Expression objects

### DIFF
--- a/docs/expressions.rst
+++ b/docs/expressions.rst
@@ -24,3 +24,37 @@ $isString as being false, it will return an Expression object; which, when cast 
 
 This will allow consumers to be able to extract types and links to elements from expressions. This allows consumers to,
 for example, interpret the default value for a constructor promoted properties when it directly instantiates an object.
+
+Creating expressions
+--------------------
+
+.. hint::
+
+   The description below is only for internal usage and to understand how expressions work, this library deals with
+   this by default.
+
+In this library, we use the ExpressionPrinter to convert a PHP-Parser node -or expression- into an expression
+like this::
+
+     $printer = new ExpressionPrinter();
+     $expressionTemplate = $printer->prettyPrintExpr($phpParserNode);
+     $expression = new Expression($expressionTemplate, $printer->getParts());
+
+In the example above we assume that there is a PHP-Parser node representing an expression; this node is passed to the
+ExpressionPrinter -which is an adapted PrettyPrinter from PHP-Parser- which will render the expression as a readable
+template string containing placeholders, and a list of parts that can slot into the placeholders.
+
+Consuming expressions
+---------------------
+
+When using this library, you can consume these expression objects either by
+
+1. Directly casting them to a string - this will replace all placeholders with the stringified version of the parts
+2. Use the render function - this will do the same as the previous methods but you can specify one or more overrides
+   for the placeholders in the expression
+
+The second method can be used to create your own string values from the given parts and render, for example, links in
+these locations.
+
+Another way to use these expressions is to interpret the parts array, and through that way know which elements and
+types are referred to in that expression.

--- a/docs/expressions.rst
+++ b/docs/expressions.rst
@@ -1,0 +1,26 @@
+Expressions
+===========
+
+Starting with version 5.4, we now support parsing expressions and extracting types and references to elements from them.
+
+.. info::
+
+   An expression is, for example, the default value for a property or argument, the definition of an enum case or a
+   constant value. These are called expressions and can contain more complex combinations of operators and values.
+
+As this library revolves around reflecting Static information, most parts of an expression are considered irrelevant;
+except for type information -such as type hints- and references to other elements, such as constants. As such, whenever
+an expression is interpreted, it will result in a string containing placeholders and an array containing the reflected
+parts -such as FQSENs-.
+
+This means that the getters like ``getDefault()`` will return a string or when you provide the optional argument
+$isString as being false, it will return an Expression object; which, when cast to string, will provide the same result.
+
+.. warning::
+
+   Deprecation: In version 6, we will remove the optional argument and always return an Expression object. When the
+   result was used as a string nothing will change, but code that checks if the output is a string will no longer
+   function starting from that version.
+
+This will allow consumers to be able to extract types and links to elements from expressions. This allows consumers to,
+for example, interpret the default value for a constructor promoted properties when it directly instantiates an object.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,4 +25,5 @@ are however several advantages to using this library:
 
    getting-started
    reflection-structure
+   expressions
    extending/index

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,7 +6,6 @@ parameters:
     ignoreErrors:
 
         - '#Method phpDocumentor\\Reflection\\File\\LocalFile::md5\(\) should return string but returns string\|false\.#'
-        - '#Else branch is unreachable because ternary operator condition is always true\.#'
         #
         # all these $fqsen errors indicate the need for a decorator class around PhpParser\Node to hold the public $fqsen that Reflection is giving it)
         #

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -29,6 +29,10 @@
     </MixedArgumentTypeCoercion>
   </file>
   <file src="src/phpDocumentor/Reflection/NodeVisitor/ElementNameResolver.php">
+    <DeprecatedClass>
+      <code><![CDATA[PropertyProperty::class]]></code>
+      <code><![CDATA[PropertyProperty::class]]></code>
+    </DeprecatedClass>
     <ImplicitToStringCast>
       <code><![CDATA[$node->name]]></code>
       <code><![CDATA[$node->name]]></code>
@@ -53,9 +57,6 @@
     <PossiblyUndefinedMethod>
       <code><![CDATA[addConstant]]></code>
     </PossiblyUndefinedMethod>
-    <RedundantCondition>
-      <code><![CDATA[$const->getValue() !== null]]></code>
-    </RedundantCondition>
   </file>
   <file src="src/phpDocumentor/Reflection/Php/Factory/ClassConstantIterator.php">
     <MixedReturnStatement>
@@ -114,11 +115,6 @@
     <MixedArgument>
       <code><![CDATA[$object->getAttribute('fqsen')]]></code>
     </MixedArgument>
-  </file>
-  <file src="src/phpDocumentor/Reflection/Php/Factory/GlobalConstant.php">
-    <RedundantCondition>
-      <code><![CDATA[$const->getValue() !== null]]></code>
-    </RedundantCondition>
   </file>
   <file src="src/phpDocumentor/Reflection/Php/Factory/GlobalConstantIterator.php">
     <MixedReturnStatement>

--- a/psalm.xml
+++ b/psalm.xml
@@ -9,6 +9,11 @@
     <projectFiles>
         <directory name="src" />
         <ignoreFiles>
+            <!--
+            ExpressionPrinter inherits all kinds of errors from PHP-Parser that I cannot fix, until a solution is found
+            we ignore this
+            -->
+            <file name="src/phpDocumentor/Reflection/Php/Expression/ExpressionPrinter.php"/>
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>

--- a/src/phpDocumentor/Reflection/NodeVisitor/ElementNameResolver.php
+++ b/src/phpDocumentor/Reflection/NodeVisitor/ElementNameResolver.php
@@ -17,6 +17,7 @@ use Override;
 use phpDocumentor\Reflection\Fqsen;
 use PhpParser\Node;
 use PhpParser\Node\Const_;
+use PhpParser\Node\PropertyItem;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassConst;
 use PhpParser\Node\Stmt\ClassMethod;
@@ -72,6 +73,7 @@ final class ElementNameResolver extends NodeVisitorAbstract
             case ClassMethod::class:
             case Trait_::class:
             case PropertyProperty::class:
+            case PropertyItem::class:
             case Node\PropertyItem::class:
             case ClassConst::class:
             case Const_::class:

--- a/src/phpDocumentor/Reflection/Php/Argument.php
+++ b/src/phpDocumentor/Reflection/Php/Argument.php
@@ -38,7 +38,7 @@ final class Argument
         /** @var string name of the Argument */
         private readonly string $name,
         Type|null $type = null,
-        /** @var string|null the default value for an argument or null if none is provided */
+        /** @var Expression|string|null the default value for an argument or null if none is provided */
         private Expression|string|null $default = null,
         /** @var bool whether the argument passes the parameter by reference instead of by value */
         private readonly bool $byReference = false,
@@ -53,7 +53,7 @@ final class Argument
             trigger_error(
                 'Default values for arguments should be of type Expression, support for strings will be '
                 . 'removed in 7.x',
-                E_USER_DEPRECATED
+                E_USER_DEPRECATED,
             );
             $this->default = new Expression($this->default, []);
         }
@@ -74,8 +74,7 @@ final class Argument
         return $this->type;
     }
 
-    /** */
-    public function getDefault(bool $asString = true): string|null
+    public function getDefault(bool $asString = true): Expression|string|null
     {
         if ($this->default === null) {
             return null;
@@ -84,7 +83,7 @@ final class Argument
         if ($asString) {
             trigger_error(
                 'The Default value will become of type Expression by default',
-                E_USER_DEPRECATED
+                E_USER_DEPRECATED,
             );
 
             return (string) $this->default;

--- a/src/phpDocumentor/Reflection/Php/Argument.php
+++ b/src/phpDocumentor/Reflection/Php/Argument.php
@@ -72,6 +72,10 @@ final class Argument
     /** */
     public function getDefault(bool $asString = true): string|null
     {
+        if ($this->default === null) {
+            return null;
+        }
+
         if ($asString) {
             trigger_error(
                 'The Default value will become of type Expression by default',

--- a/src/phpDocumentor/Reflection/Php/Argument.php
+++ b/src/phpDocumentor/Reflection/Php/Argument.php
@@ -16,6 +16,11 @@ namespace phpDocumentor\Reflection\Php;
 use phpDocumentor\Reflection\Type;
 use phpDocumentor\Reflection\Types\Mixed_;
 
+use function is_string;
+use function trigger_error;
+
+use const E_USER_DEPRECATED;
+
 /**
  * Descriptor representing a single Argument of a method or function.
  *

--- a/src/phpDocumentor/Reflection/Php/Argument.php
+++ b/src/phpDocumentor/Reflection/Php/Argument.php
@@ -34,7 +34,7 @@ final class Argument
         private readonly string $name,
         Type|null $type = null,
         /** @var string|null the default value for an argument or null if none is provided */
-        private readonly string|null $default = null,
+        private Expression|string|null $default = null,
         /** @var bool whether the argument passes the parameter by reference instead of by value */
         private readonly bool $byReference = false,
         /** @var bool Determines if this Argument represents a variadic argument */
@@ -42,6 +42,15 @@ final class Argument
     ) {
         if ($type === null) {
             $type = new Mixed_();
+        }
+
+        if (is_string($this->default)) {
+            trigger_error(
+                'Default values for arguments should be of type Expression, support for strings will be '
+                . 'removed in 7.x',
+                E_USER_DEPRECATED
+            );
+            $this->default = new Expression($this->default, []);
         }
 
         $this->type = $type;
@@ -60,8 +69,18 @@ final class Argument
         return $this->type;
     }
 
-    public function getDefault(): string|null
+    /** */
+    public function getDefault(bool $asString = true): string|null
     {
+        if ($asString) {
+            trigger_error(
+                'The Default value will become of type Expression by default',
+                E_USER_DEPRECATED
+            );
+
+            return (string) $this->default;
+        }
+
         return $this->default;
     }
 

--- a/src/phpDocumentor/Reflection/Php/Constant.php
+++ b/src/phpDocumentor/Reflection/Php/Constant.php
@@ -42,7 +42,7 @@ final class Constant implements Element, MetaDataContainerInterface, AttributeCo
     public function __construct(
         private readonly Fqsen $fqsen,
         private readonly DocBlock|null $docBlock = null,
-        private readonly string|null $value = null,
+        private Expression|string|null $value = null,
         Location|null $location = null,
         Location|null $endLocation = null,
         Visibility|null $visibility = null,
@@ -51,13 +51,31 @@ final class Constant implements Element, MetaDataContainerInterface, AttributeCo
         $this->location = $location ?: new Location(-1);
         $this->endLocation = $endLocation ?: new Location(-1);
         $this->visibility = $visibility ?: new Visibility(Visibility::PUBLIC_);
+
+        if (is_string($this->value)) {
+            trigger_error(
+                'Constant values should be of type Expression, support for strings will be '
+                . 'removed in 6.x',
+                E_USER_DEPRECATED
+            );
+            $this->value = new Expression($this->value, []);
+        }
     }
 
     /**
-     * Returns the value of this constant.
+     * Returns the expression value for this constant.
      */
-    public function getValue(): string|null
+    public function getValue(bool $asString = true): Expression|string|null
     {
+        if ($asString) {
+            trigger_error(
+                'The expression value will become of type Expression by default',
+                E_USER_DEPRECATED
+            );
+
+            return (string) $this->value;
+        }
+
         return $this->value;
     }
 

--- a/src/phpDocumentor/Reflection/Php/Constant.php
+++ b/src/phpDocumentor/Reflection/Php/Constant.php
@@ -67,6 +67,10 @@ final class Constant implements Element, MetaDataContainerInterface, AttributeCo
      */
     public function getValue(bool $asString = true): Expression|string|null
     {
+        if ($this->value === null) {
+            return null;
+        }
+
         if ($asString) {
             trigger_error(
                 'The expression value will become of type Expression by default',

--- a/src/phpDocumentor/Reflection/Php/Constant.php
+++ b/src/phpDocumentor/Reflection/Php/Constant.php
@@ -20,6 +20,11 @@ use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Location;
 use phpDocumentor\Reflection\Metadata\MetaDataContainer as MetaDataContainerInterface;
 
+use function is_string;
+use function trigger_error;
+
+use const E_USER_DEPRECATED;
+
 /**
  * Descriptor representing a constant
  *

--- a/src/phpDocumentor/Reflection/Php/Constant.php
+++ b/src/phpDocumentor/Reflection/Php/Constant.php
@@ -43,8 +43,6 @@ final class Constant implements Element, MetaDataContainerInterface, AttributeCo
 
     /**
      * Initializes the object.
-     *
-     * @param Expression|string|null $value
      */
     public function __construct(
         private readonly Fqsen $fqsen,
@@ -59,14 +57,16 @@ final class Constant implements Element, MetaDataContainerInterface, AttributeCo
         $this->endLocation = $endLocation ?: new Location(-1);
         $this->visibility = $visibility ?: new Visibility(Visibility::PUBLIC_);
 
-        if (is_string($this->value)) {
-            trigger_error(
-                'Constant values should be of type Expression, support for strings will be '
-                . 'removed in 6.x',
-                E_USER_DEPRECATED
-            );
-            $this->value = new Expression($this->value, []);
+        if (!is_string($this->value)) {
+            return;
         }
+
+        trigger_error(
+            'Constant values should be of type Expression, support for strings will be '
+            . 'removed in 6.x',
+            E_USER_DEPRECATED,
+        );
+        $this->value = new Expression($this->value, []);
     }
 
     /**
@@ -81,7 +81,7 @@ final class Constant implements Element, MetaDataContainerInterface, AttributeCo
         if ($asString) {
             trigger_error(
                 'The expression value will become of type Expression by default',
-                E_USER_DEPRECATED
+                E_USER_DEPRECATED,
             );
 
             return (string) $this->value;

--- a/src/phpDocumentor/Reflection/Php/Constant.php
+++ b/src/phpDocumentor/Reflection/Php/Constant.php
@@ -43,6 +43,8 @@ final class Constant implements Element, MetaDataContainerInterface, AttributeCo
 
     /**
      * Initializes the object.
+     *
+     * @param Expression|string|null $value
      */
     public function __construct(
         private readonly Fqsen $fqsen,

--- a/src/phpDocumentor/Reflection/Php/EnumCase.php
+++ b/src/phpDocumentor/Reflection/Php/EnumCase.php
@@ -30,7 +30,7 @@ final class EnumCase implements Element, MetaDataContainerInterface, AttributeCo
         private readonly DocBlock|null $docBlock,
         Location|null $location = null,
         Location|null $endLocation = null,
-        private readonly string|null $value = null,
+        private Expression|string|null $value = null,
     ) {
         if ($location === null) {
             $location = new Location(-1);
@@ -42,6 +42,14 @@ final class EnumCase implements Element, MetaDataContainerInterface, AttributeCo
 
         $this->location = $location;
         $this->endLocation = $endLocation;
+        if (is_string($this->value)) {
+            trigger_error(
+                'Expression values for enum cases should be of type Expression, support for strings will be '
+                . 'removed in 7.x',
+                E_USER_DEPRECATED
+            );
+            $this->value = new Expression($this->value, []);
+        }
     }
 
     #[Override]
@@ -71,8 +79,20 @@ final class EnumCase implements Element, MetaDataContainerInterface, AttributeCo
         return $this->endLocation;
     }
 
-    public function getValue(): string|null
+    /**
+     * Returns the value for this enum case.
+     */
+    public function getValue(bool $asString = true): Expression|string|null
     {
+        if ($asString) {
+            trigger_error(
+                'The enum case value will become of type Expression by default',
+                E_USER_DEPRECATED
+            );
+
+            return (string) $this->value;
+        }
+
         return $this->value;
     }
 }

--- a/src/phpDocumentor/Reflection/Php/EnumCase.php
+++ b/src/phpDocumentor/Reflection/Php/EnumCase.php
@@ -84,6 +84,10 @@ final class EnumCase implements Element, MetaDataContainerInterface, AttributeCo
      */
     public function getValue(bool $asString = true): Expression|string|null
     {
+        if ($this->value === null) {
+            return null;
+        }
+
         if ($asString) {
             trigger_error(
                 'The enum case value will become of type Expression by default',

--- a/src/phpDocumentor/Reflection/Php/EnumCase.php
+++ b/src/phpDocumentor/Reflection/Php/EnumCase.php
@@ -47,14 +47,16 @@ final class EnumCase implements Element, MetaDataContainerInterface, AttributeCo
 
         $this->location = $location;
         $this->endLocation = $endLocation;
-        if (is_string($this->value)) {
-            trigger_error(
-                'Expression values for enum cases should be of type Expression, support for strings will be '
-                . 'removed in 7.x',
-                E_USER_DEPRECATED
-            );
-            $this->value = new Expression($this->value, []);
+        if (!is_string($this->value)) {
+            return;
         }
+
+        trigger_error(
+            'Expression values for enum cases should be of type Expression, support for strings will be '
+            . 'removed in 7.x',
+            E_USER_DEPRECATED,
+        );
+        $this->value = new Expression($this->value, []);
     }
 
     #[Override]
@@ -96,7 +98,7 @@ final class EnumCase implements Element, MetaDataContainerInterface, AttributeCo
         if ($asString) {
             trigger_error(
                 'The enum case value will become of type Expression by default',
-                E_USER_DEPRECATED
+                E_USER_DEPRECATED,
             );
 
             return (string) $this->value;

--- a/src/phpDocumentor/Reflection/Php/EnumCase.php
+++ b/src/phpDocumentor/Reflection/Php/EnumCase.php
@@ -11,6 +11,11 @@ use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Location;
 use phpDocumentor\Reflection\Metadata\MetaDataContainer as MetaDataContainerInterface;
 
+use function is_string;
+use function trigger_error;
+
+use const E_USER_DEPRECATED;
+
 /**
  * Represents a case in an Enum.
  *

--- a/src/phpDocumentor/Reflection/Php/Expression.php
+++ b/src/phpDocumentor/Reflection/Php/Expression.php
@@ -7,6 +7,10 @@ namespace phpDocumentor\Reflection\Php;
 use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Type;
 
+use function array_keys;
+use function array_map;
+use function str_replace;
+
 final class Expression
 {
     private string $expression;
@@ -33,7 +37,7 @@ final class Expression
     public function __toString(): string
     {
         $valuesAsStrings = array_map(
-            static fn(object $part): string => (string)$part,
+            static fn (object $part): string => (string) $part,
             $this->parts
         );
 

--- a/src/phpDocumentor/Reflection/Php/Expression.php
+++ b/src/phpDocumentor/Reflection/Php/Expression.php
@@ -18,6 +18,9 @@ final class Expression
     /** @var array<string, Fqsen|Type> */
     private array $parts;
 
+    /**
+     * @param array<string, Fqsen|Type> $parts
+     */
     public function __construct(string $expression, array $parts)
     {
         $this->expression = $expression;
@@ -29,6 +32,9 @@ final class Expression
         return $this->expression;
     }
 
+    /**
+     * @return array<string, Fqsen|Type>
+     */
     public function getParts(): array
     {
         return $this->parts;

--- a/src/phpDocumentor/Reflection/Php/Expression.php
+++ b/src/phpDocumentor/Reflection/Php/Expression.php
@@ -5,34 +5,106 @@ declare(strict_types=1);
 namespace phpDocumentor\Reflection\Php;
 
 use phpDocumentor\Reflection\Fqsen;
+use phpDocumentor\Reflection\Php\Expression\ExpressionPrinter;
 use phpDocumentor\Reflection\Type;
+use Webmozart\Assert\Assert;
 
 use function array_keys;
-use function array_map;
+use function md5;
 use function str_replace;
 
+/**
+ * Represents an expression with a define statement, constant, property, enum case and any other location.
+ *
+ * Certain expressions contain useful references to other elements or types. Examples of these are:
+ *
+ * - Define statements that use an expression to refer to a class or function
+ * - Properties whose default value refers to a constant
+ * - Arguments whose default value initialize an object
+ * - Enum Cases that refer to a function or constant
+ *
+ * This class represents every location where an expression is used and contains 2 pieces of information:
+ *
+ * - The expression string containing placeholders linking to useful information
+ * - An array of 'parts' whose keys equal the placeholders in the expression string and whose values is the extracted
+ *   information, such as an {@see FQSEN} or {@see Type}.
+ *
+ * In a way, the expression string is similar in nature to a URI Template (see links) where you have a string containing
+ * variables that can be replaced. These variables are delimited by `{{` and `}}`, and are build up of the prefix PHPDOC
+ * and then an MD5 hash of the name of the extracted information.
+ *
+ * It is not necessary for a consumer to interpret the information when they do not need it, a {@see self::__toString()}
+ * magic method is provided that will replace the placeholders with the `toString()` output of each part.
+ *
+ * @link https://github.com/php/php-langspec/blob/master/spec/10-expressions.md
+ *     for the definition of expressions in PHP.
+ * @link https://www.rfc-editor.org/rfc/rfc6570 for more information on URI Templates.
+ * @see ExpressionPrinter how an expression coming from PHP-Parser is transformed into an expression.
+ */
 final class Expression
 {
+    /** @var string The expression string containing placeholders for any extracted Types or FQSENs. */
     private string $expression;
 
-    /** @var array<string, Fqsen|Type> */
+    /**
+     * The collection of placeholders with the value that their holding.
+     *
+     * In the expression string there can be several placeholders, this array contains a placeholder => value pair
+     * that can be used by consumers to map the data to another formatting, adding links for example, and then render
+     * the expression.
+     *
+     * @var array<string, Fqsen|Type>
+     */
     private array $parts;
+
+    /**
+     * Returns the recommended placeholder string format given a name.
+     *
+     * Consumers can use their own formats when needed, the placeholders are all keys in the {@see self::$parts} array
+     * and not interpreted by this class. However, to prevent collisions it is recommended to use this method to
+     * generate a placeholder.
+     *
+     * @param string $name a string identifying the element for which the placeholder is generated.
+     */
+    public static function generatePlaceholder(string $name): string
+    {
+        Assert::notEmpty($name);
+
+        return '{{ PHPDOC' . md5($name) . ' }}';
+    }
 
     /**
      * @param array<string, Fqsen|Type> $parts
      */
     public function __construct(string $expression, array $parts)
     {
+        Assert::notEmpty($expression);
+        Assert::allIsInstanceOfAny($parts, [Fqsen::class, Type::class]);
+
         $this->expression = $expression;
         $this->parts = $parts;
     }
 
+    /**
+     * The raw expression string containing placeholders for any extracted Types or FQSENs.
+     *
+     * @see self::render() to render a human-readable expression and to replace some parts with custom values.
+     * @see self::__toString() to render a human-readable expression with the previously extracted parts.
+     */
     public function getExpression(): string
     {
         return $this->expression;
     }
 
     /**
+     * A list of extracted parts for which placeholders exist in the expression string.
+     *
+     * The returned array will have the placeholders of the expression string as keys, and the related FQSEN or Type as
+     * value. This can be used as a basis for doing your own transformations to {@see self::render()} the expression
+     * in a custom way; or to extract type information from an expression and use that elsewhere in your application.
+     *
+     * @see ExpressionPrinter to transform a PHP-Parser expression into an expression string and list of parts.
+     *
      * @return array<string, Fqsen|Type>
      */
     public function getParts(): array
@@ -40,13 +112,36 @@ final class Expression
         return $this->parts;
     }
 
-    public function __toString(): string
+    /**
+     * Renders the expression as a string and replaces all placeholders with either a provided value, or the
+     * stringified value from the parts in this expression.
+     *
+     * The keys of the replacement parts should match those of {@see self::getParts()}, any unrecognized key is not
+     * handled.
+     *
+     * @param array<string, string> $replacementParts
+     */
+    public function render(array $replacementParts = []): string
     {
-        $valuesAsStrings = array_map(
-            static fn (object $part): string => (string) $part,
-            $this->parts
-        );
+        Assert::allStringNotEmpty($replacementParts);
+
+        $valuesAsStrings = [];
+        foreach ($this->parts as $placeholder => $part) {
+            $valuesAsStrings[$placeholder] = $replacementParts[$placeholder] ?? (string) $part;
+        }
 
         return str_replace(array_keys($this->parts), $valuesAsStrings, $this->expression);
+    }
+
+    /**
+     * Returns a rendered version of the expression string where all placeholders are replaced by the stringified
+     * versions of the included parts.
+     *
+     * @see self::$parts for the list of parts used in rendering
+     * @see self::render() to influence rendering of the expression.
+     */
+    public function __toString(): string
+    {
+        return $this->render();
     }
 }

--- a/src/phpDocumentor/Reflection/Php/Expression.php
+++ b/src/phpDocumentor/Reflection/Php/Expression.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link http://phpdoc.org
+ */
+
 namespace phpDocumentor\Reflection\Php;
 
 use phpDocumentor\Reflection\Fqsen;
@@ -76,7 +85,7 @@ final class Expression
     /**
      * @param array<string, Fqsen|Type> $parts
      */
-    public function __construct(string $expression, array $parts)
+    public function __construct(string $expression, array $parts = [])
     {
         Assert::notEmpty($expression);
         Assert::allIsInstanceOfAny($parts, [Fqsen::class, Type::class]);

--- a/src/phpDocumentor/Reflection/Php/Expression.php
+++ b/src/phpDocumentor/Reflection/Php/Expression.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Reflection\Php;
+
+use phpDocumentor\Reflection\Fqsen;
+use phpDocumentor\Reflection\Type;
+
+final class Expression
+{
+    private string $expression;
+
+    /** @var array<string, Fqsen|Type> */
+    private array $parts;
+
+    public function __construct(string $expression, array $parts)
+    {
+        $this->expression = $expression;
+        $this->parts = $parts;
+    }
+
+    public function getExpression(): string
+    {
+        return $this->expression;
+    }
+
+    public function getParts(): array
+    {
+        return $this->parts;
+    }
+
+    public function __toString(): string
+    {
+        $valuesAsStrings = array_map(
+            static fn(object $part): string => (string)$part,
+            $this->parts
+        );
+
+        return str_replace(array_keys($this->parts), $valuesAsStrings, $this->expression);
+    }
+}

--- a/src/phpDocumentor/Reflection/Php/Expression.php
+++ b/src/phpDocumentor/Reflection/Php/Expression.php
@@ -49,6 +49,8 @@ use function str_replace;
  *     for the definition of expressions in PHP.
  * @link https://www.rfc-editor.org/rfc/rfc6570 for more information on URI Templates.
  * @see ExpressionPrinter how an expression coming from PHP-Parser is transformed into an expression.
+ *
+ * @api
  */
 final class Expression
 {
@@ -82,9 +84,7 @@ final class Expression
         return '{{ PHPDOC' . md5($name) . ' }}';
     }
 
-    /**
-     * @param array<string, Fqsen|Type> $parts
-     */
+    /** @param array<string, Fqsen|Type> $parts */
     public function __construct(string $expression, array $parts = [])
     {
         Assert::notEmpty($expression);

--- a/src/phpDocumentor/Reflection/Php/Expression/ExpressionPrinter.php
+++ b/src/phpDocumentor/Reflection/Php/Expression/ExpressionPrinter.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace phpDocumentor\Reflection\Php\Expression;
 
 use phpDocumentor\Reflection\Fqsen;
+use phpDocumentor\Reflection\Php\Expression;
+use phpDocumentor\Reflection\Type;
 use PhpParser\Node\Name;
 use PhpParser\PrettyPrinter\Standard;
 
-use function md5;
-
 final class ExpressionPrinter extends Standard
 {
-    /** @var array<Fqsen> */
+    /** @var array<string, Fqsen|Type> */
     private array $parts = [];
 
     protected function resetState(): void
@@ -25,16 +25,24 @@ final class ExpressionPrinter extends Standard
     protected function pName(Name $node): string
     {
         $renderedName = parent::pName($node);
-        $code = md5($renderedName);
+        $placeholder = Expression::generatePlaceholder($renderedName);
+        $this->parts[$placeholder] = new Fqsen('\\' . $renderedName);
 
-        $placeholder = '{{ PHPDOC' . $code . ' }}';
-        $this->parts[$placeholder] = new Fqsen('\\' . $node);
+        return $placeholder;
+    }
+
+    // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    protected function pName_FullyQualified(Name\FullyQualified $node): string
+    {
+        $renderedName = parent::pName_FullyQualified($node);
+        $placeholder = Expression::generatePlaceholder($renderedName);
+        $this->parts[$placeholder] = new Fqsen($renderedName);
 
         return $placeholder;
     }
 
     /**
-     * @return array<Fqsen>
+     * @return array<string, Fqsen|Type>
      */
     public function getParts(): array
     {

--- a/src/phpDocumentor/Reflection/Php/Expression/ExpressionPrinter.php
+++ b/src/phpDocumentor/Reflection/Php/Expression/ExpressionPrinter.php
@@ -8,11 +8,11 @@ use phpDocumentor\Reflection\Fqsen;
 use PhpParser\Node\Name;
 use PhpParser\PrettyPrinter\Standard;
 
+use function md5;
+
 final class ExpressionPrinter extends Standard
 {
-    /**
-     * @var array<Fqsen>
-     */
+    /** @var array<Fqsen> */
     private array $parts = [];
 
     protected function resetState(): void

--- a/src/phpDocumentor/Reflection/Php/Expression/ExpressionPrinter.php
+++ b/src/phpDocumentor/Reflection/Php/Expression/ExpressionPrinter.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Reflection\Php\Expression;
+
+use phpDocumentor\Reflection\Fqsen;
+use PhpParser\Node\Name;
+use PhpParser\PrettyPrinter\Standard;
+
+final class ExpressionPrinter extends Standard
+{
+    /**
+     * @var array<Fqsen>
+     */
+    private array $parts = [];
+
+    protected function resetState(): void
+    {
+        parent::resetState();
+
+        $this->parts = [];
+    }
+
+    protected function pName(Name $node): string
+    {
+        $renderedName = parent::pName($node);
+        $code = md5($renderedName);
+
+        $placeholder = '{{ PHPDOC' . $code . ' }}';
+        $this->parts[$placeholder] = new Fqsen('\\' . $node);
+
+        return $placeholder;
+    }
+
+    /**
+     * @return array<Fqsen>
+     */
+    public function getParts(): array
+    {
+        return $this->parts;
+    }
+}

--- a/src/phpDocumentor/Reflection/Php/Expression/ExpressionPrinter.php
+++ b/src/phpDocumentor/Reflection/Php/Expression/ExpressionPrinter.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link http://phpdoc.org
+ */
+
 namespace phpDocumentor\Reflection\Php\Expression;
 
 use phpDocumentor\Reflection\Fqsen;

--- a/src/phpDocumentor/Reflection/Php/Expression/ExpressionPrinter.php
+++ b/src/phpDocumentor/Reflection/Php/Expression/ExpressionPrinter.php
@@ -16,6 +16,7 @@ namespace phpDocumentor\Reflection\Php\Expression;
 use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Php\Expression;
 use phpDocumentor\Reflection\Type;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Name;
 use PhpParser\PrettyPrinter\Standard;
 
@@ -50,9 +51,20 @@ final class ExpressionPrinter extends Standard
         return $placeholder;
     }
 
-    /**
-     * @return array<string, Fqsen|Type>
-     */
+    // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    protected function pExpr_ClassConstFetch(Expr\ClassConstFetch $node): string
+    {
+        $renderedName = parent::pObjectProperty($node->name);
+        $className = $node->class instanceof Name ? parent::pName($node->class) : $this->p($node->class);
+        $placeholder = Expression::generatePlaceholder($renderedName);
+        $this->parts[$placeholder] = new Fqsen(
+            '\\' . $className . '::' . $renderedName,
+        );
+
+        return $placeholder;
+    }
+
+    /** @return array<string, Fqsen|Type> */
     public function getParts(): array
     {
         return $this->parts;

--- a/src/phpDocumentor/Reflection/Php/Expression/ExpressionPrinter.php
+++ b/src/phpDocumentor/Reflection/Php/Expression/ExpressionPrinter.php
@@ -14,8 +14,10 @@ declare(strict_types=1);
 namespace phpDocumentor\Reflection\Php\Expression;
 
 use phpDocumentor\Reflection\Fqsen;
+use phpDocumentor\Reflection\FqsenResolver;
 use phpDocumentor\Reflection\Php\Expression;
 use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Types\Context;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Name;
 use PhpParser\PrettyPrinter\Standard;
@@ -24,6 +26,16 @@ final class ExpressionPrinter extends Standard
 {
     /** @var array<string, Fqsen|Type> */
     private array $parts = [];
+    private Context|null $context = null;
+    private FqsenResolver $fqsenResolver;
+
+    /** {@inheritDoc} */
+    public function __construct(array $options = [])
+    {
+        parent::__construct($options);
+
+        $this->fqsenResolver = new FqsenResolver();
+    }
 
     protected function resetState(): void
     {
@@ -32,11 +44,18 @@ final class ExpressionPrinter extends Standard
         $this->parts = [];
     }
 
+    public function prettyPrintExpr(Expr $node, Context|null $context = null): string
+    {
+        $this->context = $context;
+
+        return parent::prettyPrintExpr($node);
+    }
+
     protected function pName(Name $node): string
     {
-        $renderedName = parent::pName($node);
-        $placeholder = Expression::generatePlaceholder($renderedName);
-        $this->parts[$placeholder] = new Fqsen('\\' . $renderedName);
+        $renderedName = $this->fqsenResolver->resolve(parent::pName($node), $this->context);
+        $placeholder = Expression::generatePlaceholder((string) $renderedName);
+        $this->parts[$placeholder] = $renderedName;
 
         return $placeholder;
     }
@@ -56,7 +75,7 @@ final class ExpressionPrinter extends Standard
     {
         $renderedName = parent::pObjectProperty($node->name);
         $className = $node->class instanceof Name ? parent::pName($node->class) : $this->p($node->class);
-        $placeholder = Expression::generatePlaceholder($renderedName);
+        $placeholder = Expression::generatePlaceholder((string) $renderedName);
         $this->parts[$placeholder] = new Fqsen(
             '\\' . $className . '::' . $renderedName,
         );

--- a/src/phpDocumentor/Reflection/Php/Factory/ClassConstant.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/ClassConstant.php
@@ -19,9 +19,9 @@ use phpDocumentor\Reflection\Location;
 use phpDocumentor\Reflection\Php\Class_;
 use phpDocumentor\Reflection\Php\Constant as ConstantElement;
 use phpDocumentor\Reflection\Php\Enum_;
-use phpDocumentor\Reflection\Php\Factory\Reducer\Reducer;
 use phpDocumentor\Reflection\Php\Expression;
 use phpDocumentor\Reflection\Php\Expression\ExpressionPrinter;
+use phpDocumentor\Reflection\Php\Factory\Reducer\Reducer;
 use phpDocumentor\Reflection\Php\Interface_;
 use phpDocumentor\Reflection\Php\StrategyContainer;
 use phpDocumentor\Reflection\Php\Trait_;
@@ -109,7 +109,7 @@ final class ClassConstant extends AbstractFactory
         return null;
     }
 
-    private function determineValue(ClassConstantIterator $value): Expression|null
+    private function determineValue(ClassConstantIterator $value): Expression
     {
         $expression = $this->valueConverter->prettyPrintExpr($value->getValue());
         if ($this->valueConverter instanceof ExpressionPrinter) {

--- a/src/phpDocumentor/Reflection/Php/Factory/ClassConstant.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/ClassConstant.php
@@ -109,13 +109,9 @@ final class ClassConstant extends AbstractFactory
         return null;
     }
 
-    private function determineValue(ClassConstantIterator $value): null|Expression
+    private function determineValue(ClassConstantIterator $value): Expression|null
     {
-        $expression = $value->getValue() !== null ? $this->valueConverter->prettyPrintExpr($value->getValue()) : null;
-        if ($expression === null) {
-            return null;
-        }
-
+        $expression = $this->valueConverter->prettyPrintExpr($value->getValue());
         if ($this->valueConverter instanceof ExpressionPrinter) {
             $expression = new Expression($expression, $this->valueConverter->getParts());
         }

--- a/src/phpDocumentor/Reflection/Php/Factory/ClassConstant.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/ClassConstant.php
@@ -20,6 +20,8 @@ use phpDocumentor\Reflection\Php\Class_;
 use phpDocumentor\Reflection\Php\Constant as ConstantElement;
 use phpDocumentor\Reflection\Php\Enum_;
 use phpDocumentor\Reflection\Php\Factory\Reducer\Reducer;
+use phpDocumentor\Reflection\Php\Expression;
+use phpDocumentor\Reflection\Php\Expression\ExpressionPrinter;
 use phpDocumentor\Reflection\Php\Interface_;
 use phpDocumentor\Reflection\Php\StrategyContainer;
 use phpDocumentor\Reflection\Php\Trait_;
@@ -84,7 +86,7 @@ final class ClassConstant extends AbstractFactory
             $constant = new ConstantElement(
                 $const->getFqsen(),
                 $this->createDocBlock($const->getDocComment(), $context->getTypeContext()),
-                $const->getValue() !== null ? $this->valueConverter->prettyPrintExpr($const->getValue()) : null,
+                $this->determineValue($const),
                 new Location($const->getLine()),
                 new Location($const->getEndLine()),
                 $this->buildVisibility($const),
@@ -103,6 +105,19 @@ final class ClassConstant extends AbstractFactory
         }
 
         return null;
+    }
+
+    private function determineValue(ClassConstantIterator $value): null|Expression
+    {
+        $expression = $value->getValue() !== null ? $this->valueConverter->prettyPrintExpr($value->getValue()) : null;
+        if ($this->valueConverter instanceof ExpressionPrinter) {
+            $expression = new Expression($expression, $this->valueConverter->getParts());
+        }
+        if (is_string($expression)) {
+            $expression = new Expression($expression, []);
+        }
+
+        return $expression;
     }
 
     /**

--- a/src/phpDocumentor/Reflection/Php/Factory/ClassConstant.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/ClassConstant.php
@@ -112,6 +112,10 @@ final class ClassConstant extends AbstractFactory
     private function determineValue(ClassConstantIterator $value): null|Expression
     {
         $expression = $value->getValue() !== null ? $this->valueConverter->prettyPrintExpr($value->getValue()) : null;
+        if ($expression === null) {
+            return null;
+        }
+
         if ($this->valueConverter instanceof ExpressionPrinter) {
             $expression = new Expression($expression, $this->valueConverter->getParts());
         }

--- a/src/phpDocumentor/Reflection/Php/Factory/ClassConstant.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/ClassConstant.php
@@ -30,6 +30,8 @@ use PhpParser\Node\Stmt\ClassConst;
 use PhpParser\PrettyPrinter\Standard as PrettyPrinter;
 use Webmozart\Assert\Assert;
 
+use function is_string;
+
 /**
  * Strategy to convert ClassConstantIterator to ConstantElement
  *
@@ -113,6 +115,7 @@ final class ClassConstant extends AbstractFactory
         if ($this->valueConverter instanceof ExpressionPrinter) {
             $expression = new Expression($expression, $this->valueConverter->getParts());
         }
+
         if (is_string($expression)) {
             $expression = new Expression($expression, []);
         }

--- a/src/phpDocumentor/Reflection/Php/Factory/ConstructorPromotion.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/ConstructorPromotion.php
@@ -11,6 +11,8 @@ use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Location;
 use phpDocumentor\Reflection\Php\Class_ as ClassElement;
 use phpDocumentor\Reflection\Php\Factory\Reducer\Reducer;
+use phpDocumentor\Reflection\Php\Expression;
+use phpDocumentor\Reflection\Php\Expression\ExpressionPrinter;
 use phpDocumentor\Reflection\Php\ProjectFactoryStrategy;
 use phpDocumentor\Reflection\Php\StrategyContainer;
 use PhpParser\Modifiers;
@@ -19,6 +21,8 @@ use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\PrettyPrinter\Standard as PrettyPrinter;
 use Webmozart\Assert\Assert;
+
+use function is_string;
 
 final class ConstructorPromotion extends AbstractFactory
 {
@@ -76,7 +80,7 @@ final class ConstructorPromotion extends AbstractFactory
             ->visibility($param)
             ->type($param->type)
             ->docblock($param->getDocComment())
-            ->default($param->default)
+            ->default($this->determineDefault($param))
             ->readOnly($this->readOnly($param->flags))
             ->static(false)
             ->startLocation(new Location($param->getLine(), $param->getStartFilePos()))
@@ -93,6 +97,24 @@ final class ConstructorPromotion extends AbstractFactory
         }
 
         $methodContainer->addProperty($property);
+    }
+
+    private function determineDefault(Param $value): Expression|null
+    {
+        $expression = $value->default !== null ? $this->valueConverter->prettyPrintExpr($value->default) : null;
+        if ($expression === null) {
+            return null;
+        }
+
+        if ($this->valueConverter instanceof ExpressionPrinter) {
+            $expression = new Expression($expression, $this->valueConverter->getParts());
+        }
+
+        if (is_string($expression)) {
+            $expression = new Expression($expression, []);
+        }
+
+        return $expression;
     }
 
     private function readOnly(int $flags): bool

--- a/src/phpDocumentor/Reflection/Php/Factory/ConstructorPromotion.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/ConstructorPromotion.php
@@ -11,8 +11,6 @@ use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Location;
 use phpDocumentor\Reflection\Php\Class_ as ClassElement;
 use phpDocumentor\Reflection\Php\Factory\Reducer\Reducer;
-use phpDocumentor\Reflection\Php\Expression;
-use phpDocumentor\Reflection\Php\Expression\ExpressionPrinter;
 use phpDocumentor\Reflection\Php\ProjectFactoryStrategy;
 use phpDocumentor\Reflection\Php\StrategyContainer;
 use PhpParser\Modifiers;
@@ -21,8 +19,6 @@ use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\PrettyPrinter\Standard as PrettyPrinter;
 use Webmozart\Assert\Assert;
-
-use function is_string;
 
 final class ConstructorPromotion extends AbstractFactory
 {
@@ -80,11 +76,11 @@ final class ConstructorPromotion extends AbstractFactory
             ->visibility($param)
             ->type($param->type)
             ->docblock($param->getDocComment())
-            ->default($this->determineDefault($param))
+            ->default($param->default)
             ->readOnly($this->readOnly($param->flags))
             ->static(false)
-            ->startLocation(new Location($param->getLine(), $param->getStartFilePos()))
-            ->endLocation(new Location($param->getEndLine(), $param->getEndFilePos()))
+            ->startLocation(new Location($param->getLine()))
+            ->endLocation(new Location($param->getEndLine()))
             ->hooks($param->hooks ?? [])
             ->build($context);
 
@@ -97,24 +93,6 @@ final class ConstructorPromotion extends AbstractFactory
         }
 
         $methodContainer->addProperty($property);
-    }
-
-    private function determineDefault(Param $value): Expression|null
-    {
-        $expression = $value->default !== null ? $this->valueConverter->prettyPrintExpr($value->default) : null;
-        if ($expression === null) {
-            return null;
-        }
-
-        if ($this->valueConverter instanceof ExpressionPrinter) {
-            $expression = new Expression($expression, $this->valueConverter->getParts());
-        }
-
-        if (is_string($expression)) {
-            $expression = new Expression($expression, []);
-        }
-
-        return $expression;
     }
 
     private function readOnly(int $flags): bool

--- a/src/phpDocumentor/Reflection/Php/Factory/Define.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Define.php
@@ -127,11 +127,7 @@ final class Define extends AbstractFactory
             return null;
         }
 
-        $expression = $value->value !== null ? $this->valueConverter->prettyPrintExpr($value->value) : null;
-        if ($expression === null) {
-            return null;
-        }
-
+        $expression = $this->valueConverter->prettyPrintExpr($value->value);
         if ($this->valueConverter instanceof ExpressionPrinter) {
             $expression = new ValueExpression($expression, $this->valueConverter->getParts());
         }

--- a/src/phpDocumentor/Reflection/Php/Factory/Define.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Define.php
@@ -18,6 +18,8 @@ use phpDocumentor\Reflection\DocBlockFactoryInterface;
 use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Location;
 use phpDocumentor\Reflection\Php\Constant as ConstantElement;
+use phpDocumentor\Reflection\Php\Expression as ValueExpression;
+use phpDocumentor\Reflection\Php\Expression\ExpressionPrinter;
 use phpDocumentor\Reflection\Php\File as FileElement;
 use phpDocumentor\Reflection\Php\StrategyContainer;
 use phpDocumentor\Reflection\Php\ValueEvaluator\ConstantEvaluator;
@@ -118,13 +120,21 @@ final class Define extends AbstractFactory
         return $constant;
     }
 
-    private function determineValue(Arg|null $value): string|null
+    private function determineValue(Arg|null $value): ValueExpression|null
     {
         if ($value === null) {
             return null;
         }
 
-        return $this->valueConverter->prettyPrintExpr($value->value);
+        $expression = $value->value !== null ? $this->valueConverter->prettyPrintExpr($value->value) : null;
+        if ($this->valueConverter instanceof ExpressionPrinter) {
+            $expression = new ValueExpression($expression, $this->valueConverter->getParts());
+        }
+        if (is_string($expression)) {
+            $expression = new ValueExpression($expression, []);
+        }
+
+        return $expression;
     }
 
     private function determineFqsen(Arg $name, ContextStack $context): Fqsen|null

--- a/src/phpDocumentor/Reflection/Php/Factory/Define.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Define.php
@@ -128,6 +128,10 @@ final class Define extends AbstractFactory
         }
 
         $expression = $value->value !== null ? $this->valueConverter->prettyPrintExpr($value->value) : null;
+        if ($expression === null) {
+            return null;
+        }
+
         if ($this->valueConverter instanceof ExpressionPrinter) {
             $expression = new ValueExpression($expression, $this->valueConverter->getParts());
         }

--- a/src/phpDocumentor/Reflection/Php/Factory/Define.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Define.php
@@ -33,6 +33,7 @@ use PhpParser\Node\VariadicPlaceholder;
 use PhpParser\PrettyPrinter\Standard as PrettyPrinter;
 
 use function assert;
+use function is_string;
 use function sprintf;
 use function str_starts_with;
 
@@ -130,6 +131,7 @@ final class Define extends AbstractFactory
         if ($this->valueConverter instanceof ExpressionPrinter) {
             $expression = new ValueExpression($expression, $this->valueConverter->getParts());
         }
+
         if (is_string($expression)) {
             $expression = new ValueExpression($expression, []);
         }

--- a/src/phpDocumentor/Reflection/Php/Factory/EnumCase.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/EnumCase.php
@@ -11,12 +11,14 @@ use phpDocumentor\Reflection\Php\Enum_ as EnumElement;
 use phpDocumentor\Reflection\Php\EnumCase as EnumCaseElement;
 use phpDocumentor\Reflection\Php\Factory\Reducer\Reducer;
 use phpDocumentor\Reflection\Php\Expression;
+use phpDocumentor\Reflection\Php\Expression as ValueExpression;
 use phpDocumentor\Reflection\Php\Expression\ExpressionPrinter;
 use phpDocumentor\Reflection\Php\StrategyContainer;
 use PhpParser\Node\Stmt\EnumCase as EnumCaseNode;
 use PhpParser\PrettyPrinter\Standard as PrettyPrinter;
 
 use function assert;
+use function is_string;
 
 final class EnumCase extends AbstractFactory
 {
@@ -43,21 +45,30 @@ final class EnumCase extends AbstractFactory
         $enum = $context->peek();
         assert($enum instanceof EnumElement);
 
-        $value = $object->expr !== null ? $this->prettyPrinter->prettyPrintExpr($object->expr) : null;
-        if ($this->prettyPrinter instanceof ExpressionPrinter) {
-            $value = new Expression($value, $this->prettyPrinter->getParts());
-        }
-
-        $case = new EnumCaseElement(
+        $enum->addCase(new EnumCaseElement(
             $object->getAttribute('fqsen'),
             $docBlock,
             new Location($object->getLine()),
             new Location($object->getEndLine()),
-            $value,
-        );
+            $this->determineValue($object),
+        ));
+    }
 
-        $enum->addCase($case);
+    private function determineValue(EnumCaseNode $value): ValueExpression|null
+    {
+        $expression = $value->expr !== null ? $this->prettyPrinter->prettyPrintExpr($value->expr) : null;
+        if ($expression === null) {
+            return null;
+        }
 
-        return $case;
+        if ($this->prettyPrinter instanceof ExpressionPrinter) {
+            $expression = new ValueExpression($expression, $this->prettyPrinter->getParts());
+        }
+
+        if (is_string($expression)) {
+            $expression = new ValueExpression($expression, []);
+        }
+
+        return $expression;
     }
 }

--- a/src/phpDocumentor/Reflection/Php/Factory/EnumCase.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/EnumCase.php
@@ -10,7 +10,6 @@ use phpDocumentor\Reflection\Location;
 use phpDocumentor\Reflection\Php\Enum_ as EnumElement;
 use phpDocumentor\Reflection\Php\EnumCase as EnumCaseElement;
 use phpDocumentor\Reflection\Php\Factory\Reducer\Reducer;
-use phpDocumentor\Reflection\Php\Expression;
 use phpDocumentor\Reflection\Php\Expression as ValueExpression;
 use phpDocumentor\Reflection\Php\Expression\ExpressionPrinter;
 use phpDocumentor\Reflection\Php\StrategyContainer;

--- a/src/phpDocumentor/Reflection/Php/Factory/EnumCase.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/EnumCase.php
@@ -10,6 +10,8 @@ use phpDocumentor\Reflection\Location;
 use phpDocumentor\Reflection\Php\Enum_ as EnumElement;
 use phpDocumentor\Reflection\Php\EnumCase as EnumCaseElement;
 use phpDocumentor\Reflection\Php\Factory\Reducer\Reducer;
+use phpDocumentor\Reflection\Php\Expression;
+use phpDocumentor\Reflection\Php\Expression\ExpressionPrinter;
 use phpDocumentor\Reflection\Php\StrategyContainer;
 use PhpParser\Node\Stmt\EnumCase as EnumCaseNode;
 use PhpParser\PrettyPrinter\Standard as PrettyPrinter;
@@ -41,12 +43,17 @@ final class EnumCase extends AbstractFactory
         $enum = $context->peek();
         assert($enum instanceof EnumElement);
 
+        $value = $object->expr !== null ? $this->prettyPrinter->prettyPrintExpr($object->expr) : null;
+        if ($this->prettyPrinter instanceof ExpressionPrinter) {
+            $value = new Expression($value, $this->prettyPrinter->getParts());
+        }
+
         $case = new EnumCaseElement(
             $object->getAttribute('fqsen'),
             $docBlock,
             new Location($object->getLine()),
             new Location($object->getEndLine()),
-            $object->expr !== null ? $this->prettyPrinter->prettyPrintExpr($object->expr) : null,
+            $value,
         );
 
         $enum->addCase($case);

--- a/src/phpDocumentor/Reflection/Php/Factory/EnumCase.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/EnumCase.php
@@ -9,9 +9,9 @@ use phpDocumentor\Reflection\DocBlockFactoryInterface;
 use phpDocumentor\Reflection\Location;
 use phpDocumentor\Reflection\Php\Enum_ as EnumElement;
 use phpDocumentor\Reflection\Php\EnumCase as EnumCaseElement;
-use phpDocumentor\Reflection\Php\Factory\Reducer\Reducer;
 use phpDocumentor\Reflection\Php\Expression as ValueExpression;
 use phpDocumentor\Reflection\Php\Expression\ExpressionPrinter;
+use phpDocumentor\Reflection\Php\Factory\Reducer\Reducer;
 use phpDocumentor\Reflection\Php\StrategyContainer;
 use PhpParser\Node\Stmt\EnumCase as EnumCaseNode;
 use PhpParser\PrettyPrinter\Standard as PrettyPrinter;
@@ -44,13 +44,17 @@ final class EnumCase extends AbstractFactory
         $enum = $context->peek();
         assert($enum instanceof EnumElement);
 
-        $enum->addCase(new EnumCaseElement(
+        $case = new EnumCaseElement(
             $object->getAttribute('fqsen'),
             $docBlock,
             new Location($object->getLine()),
             new Location($object->getEndLine()),
             $this->determineValue($object),
-        ));
+        );
+
+        $enum->addCase($case);
+
+        return $case;
     }
 
     private function determineValue(EnumCaseNode $value): ValueExpression|null

--- a/src/phpDocumentor/Reflection/Php/Factory/GlobalConstant.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/GlobalConstant.php
@@ -87,6 +87,10 @@ final class GlobalConstant extends AbstractFactory
     private function determineValue(GlobalConstantIterator $value): ?Expression
     {
         $expression = $value->getValue() !== null ? $this->valueConverter->prettyPrintExpr($value->getValue()) : null;
+        if ($expression === null) {
+            return null;
+        }
+
         if ($this->valueConverter instanceof ExpressionPrinter) {
             $expression = new Expression($expression, $this->valueConverter->getParts());
         }

--- a/src/phpDocumentor/Reflection/Php/Factory/GlobalConstant.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/GlobalConstant.php
@@ -84,13 +84,9 @@ final class GlobalConstant extends AbstractFactory
         return null;
     }
 
-    private function determineValue(GlobalConstantIterator $value): ?Expression
+    private function determineValue(GlobalConstantIterator $value): Expression
     {
-        $expression = $value->getValue() !== null ? $this->valueConverter->prettyPrintExpr($value->getValue()) : null;
-        if ($expression === null) {
-            return null;
-        }
-
+        $expression = $this->valueConverter->prettyPrintExpr($value->getValue());
         if ($this->valueConverter instanceof ExpressionPrinter) {
             $expression = new Expression($expression, $this->valueConverter->getParts());
         }

--- a/src/phpDocumentor/Reflection/Php/Factory/GlobalConstant.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/GlobalConstant.php
@@ -25,6 +25,8 @@ use PhpParser\Node\Stmt\Const_;
 use PhpParser\PrettyPrinter\Standard as PrettyPrinter;
 use Webmozart\Assert\Assert;
 
+use function is_string;
+
 /**
  * Strategy to convert GlobalConstantIterator to ConstantElement
  *
@@ -88,6 +90,7 @@ final class GlobalConstant extends AbstractFactory
         if ($this->valueConverter instanceof ExpressionPrinter) {
             $expression = new Expression($expression, $this->valueConverter->getParts());
         }
+
         if (is_string($expression)) {
             $expression = new Expression($expression, []);
         }

--- a/src/phpDocumentor/Reflection/Php/Factory/GlobalConstant.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/GlobalConstant.php
@@ -17,6 +17,8 @@ use Override;
 use phpDocumentor\Reflection\DocBlockFactoryInterface;
 use phpDocumentor\Reflection\Location;
 use phpDocumentor\Reflection\Php\Constant as ConstantElement;
+use phpDocumentor\Reflection\Php\Expression;
+use phpDocumentor\Reflection\Php\Expression\ExpressionPrinter;
 use phpDocumentor\Reflection\Php\File as FileElement;
 use phpDocumentor\Reflection\Php\StrategyContainer;
 use PhpParser\Node\Stmt\Const_;
@@ -70,7 +72,7 @@ final class GlobalConstant extends AbstractFactory
                 new ConstantElement(
                     $const->getFqsen(),
                     $this->createDocBlock($const->getDocComment(), $context->getTypeContext()),
-                    $const->getValue() !== null ? $this->valueConverter->prettyPrintExpr($const->getValue()) : null,
+                    $this->determineValue($const),
                     new Location($const->getLine()),
                     new Location($const->getEndLine()),
                 ),
@@ -78,5 +80,18 @@ final class GlobalConstant extends AbstractFactory
         }
 
         return null;
+    }
+
+    private function determineValue(GlobalConstantIterator $value): ?Expression
+    {
+        $expression = $value->getValue() !== null ? $this->valueConverter->prettyPrintExpr($value->getValue()) : null;
+        if ($this->valueConverter instanceof ExpressionPrinter) {
+            $expression = new Expression($expression, $this->valueConverter->getParts());
+        }
+        if (is_string($expression)) {
+            $expression = new Expression($expression, []);
+        }
+
+        return $expression;
     }
 }

--- a/src/phpDocumentor/Reflection/Php/Factory/Property.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Property.php
@@ -115,6 +115,10 @@ final class Property extends AbstractFactory
             ? $this->valueConverter->prettyPrintExpr($value->getDefault())
             : null;
 
+        if ($expression === null) {
+            return null;
+        }
+
         if ($this->valueConverter instanceof ExpressionPrinter) {
             $expression = new Expression($expression, $this->valueConverter->getParts());
         }

--- a/src/phpDocumentor/Reflection/Php/Factory/Property.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Property.php
@@ -111,10 +111,8 @@ final class Property extends AbstractFactory
 
     private function determineDefault(PropertyIterator $value): Expression|null
     {
-        $expression = $value->getDefault() !== null
-            ? $this->valueConverter->prettyPrintExpr($value->getDefault())
-            : null;
-
+        $default = $value->getDefault();
+        $expression = $default !== null ? $this->valueConverter->prettyPrintExpr($default) : null;
         if ($expression === null) {
             return null;
         }

--- a/src/phpDocumentor/Reflection/Php/Factory/Property.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Property.php
@@ -27,6 +27,8 @@ use PhpParser\Node\Stmt\Property as PropertyNode;
 use PhpParser\PrettyPrinter\Standard as PrettyPrinter;
 use Webmozart\Assert\Assert;
 
+use function is_string;
+
 /**
  * Strategy to convert PropertyIterator to PropertyDescriptor
  *

--- a/src/phpDocumentor/Reflection/Php/Factory/Property.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Property.php
@@ -20,7 +20,6 @@ use phpDocumentor\Reflection\Php\Class_;
 use phpDocumentor\Reflection\Php\Factory\Reducer\Reducer;
 use phpDocumentor\Reflection\Php\Expression;
 use phpDocumentor\Reflection\Php\Expression\ExpressionPrinter;
-use phpDocumentor\Reflection\Php\ProjectFactoryStrategy;
 use phpDocumentor\Reflection\Php\Property as PropertyDescriptor;
 use phpDocumentor\Reflection\Php\StrategyContainer;
 use phpDocumentor\Reflection\Php\Trait_;
@@ -77,11 +76,6 @@ final class Property extends AbstractFactory
 
         $iterator = new PropertyIterator($object);
         foreach ($iterator as $stmt) {
-            $default = $object->default !== null ? $this->valueConverter->prettyPrintExpr($object->default) : null;
-            if ($this->valueConverter instanceof ExpressionPrinter) {
-                $default = new Expression($default, $this->valueConverter->getParts());
-            }
-
             $property = PropertyBuilder::create(
                 $this->valueConverter,
                 $this->docBlockFactory,
@@ -92,7 +86,7 @@ final class Property extends AbstractFactory
                 ->visibility($stmt)
                 ->type($stmt->getType())
                 ->docblock($stmt->getDocComment())
-                ->default($default)
+                ->default($this->determineDefault($stmt))
                 ->static($stmt->isStatic())
                 ->startLocation(new Location($stmt->getLine()))
                 ->endLocation(new Location($stmt->getEndLine()))
@@ -109,8 +103,24 @@ final class Property extends AbstractFactory
             }
 
             $propertyContainer->addProperty($property);
+
+        }
+    }
+
+    private function determineDefault(PropertyIterator $value): Expression|null
+    {
+        $expression = $value->getDefault() !== null
+            ? $this->valueConverter->prettyPrintExpr($value->getDefault())
+            : null;
+
+        if ($this->valueConverter instanceof ExpressionPrinter) {
+            $expression = new Expression($expression, $this->valueConverter->getParts());
         }
 
-        return null;
+        if (is_string($expression)) {
+            $expression = new Expression($expression, []);
+        }
+
+        return $expression;
     }
 }

--- a/src/phpDocumentor/Reflection/Php/Factory/Property.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Property.php
@@ -18,16 +18,12 @@ use phpDocumentor\Reflection\DocBlockFactoryInterface;
 use phpDocumentor\Reflection\Location;
 use phpDocumentor\Reflection\Php\Class_;
 use phpDocumentor\Reflection\Php\Factory\Reducer\Reducer;
-use phpDocumentor\Reflection\Php\Expression;
-use phpDocumentor\Reflection\Php\Expression\ExpressionPrinter;
 use phpDocumentor\Reflection\Php\Property as PropertyDescriptor;
 use phpDocumentor\Reflection\Php\StrategyContainer;
 use phpDocumentor\Reflection\Php\Trait_;
 use PhpParser\Node\Stmt\Property as PropertyNode;
 use PhpParser\PrettyPrinter\Standard as PrettyPrinter;
 use Webmozart\Assert\Assert;
-
-use function is_string;
 
 /**
  * Strategy to convert PropertyIterator to PropertyDescriptor
@@ -88,7 +84,7 @@ final class Property extends AbstractFactory
                 ->visibility($stmt)
                 ->type($stmt->getType())
                 ->docblock($stmt->getDocComment())
-                ->default($this->determineDefault($stmt))
+                ->default($stmt->getDefault())
                 ->static($stmt->isStatic())
                 ->startLocation(new Location($stmt->getLine()))
                 ->endLocation(new Location($stmt->getEndLine()))
@@ -105,26 +101,8 @@ final class Property extends AbstractFactory
             }
 
             $propertyContainer->addProperty($property);
-
-        }
-    }
-
-    private function determineDefault(PropertyIterator $value): Expression|null
-    {
-        $default = $value->getDefault();
-        $expression = $default !== null ? $this->valueConverter->prettyPrintExpr($default) : null;
-        if ($expression === null) {
-            return null;
         }
 
-        if ($this->valueConverter instanceof ExpressionPrinter) {
-            $expression = new Expression($expression, $this->valueConverter->getParts());
-        }
-
-        if (is_string($expression)) {
-            $expression = new Expression($expression, []);
-        }
-
-        return $expression;
+        return null;
     }
 }

--- a/src/phpDocumentor/Reflection/Php/Factory/Property.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Property.php
@@ -18,6 +18,9 @@ use phpDocumentor\Reflection\DocBlockFactoryInterface;
 use phpDocumentor\Reflection\Location;
 use phpDocumentor\Reflection\Php\Class_;
 use phpDocumentor\Reflection\Php\Factory\Reducer\Reducer;
+use phpDocumentor\Reflection\Php\Expression;
+use phpDocumentor\Reflection\Php\Expression\ExpressionPrinter;
+use phpDocumentor\Reflection\Php\ProjectFactoryStrategy;
 use phpDocumentor\Reflection\Php\Property as PropertyDescriptor;
 use phpDocumentor\Reflection\Php\StrategyContainer;
 use phpDocumentor\Reflection\Php\Trait_;
@@ -74,6 +77,11 @@ final class Property extends AbstractFactory
 
         $iterator = new PropertyIterator($object);
         foreach ($iterator as $stmt) {
+            $default = $object->default !== null ? $this->valueConverter->prettyPrintExpr($object->default) : null;
+            if ($this->valueConverter instanceof ExpressionPrinter) {
+                $default = new Expression($default, $this->valueConverter->getParts());
+            }
+
             $property = PropertyBuilder::create(
                 $this->valueConverter,
                 $this->docBlockFactory,
@@ -84,7 +92,7 @@ final class Property extends AbstractFactory
                 ->visibility($stmt)
                 ->type($stmt->getType())
                 ->docblock($stmt->getDocComment())
-                ->default($iterator->getDefault())
+                ->default($default)
                 ->static($stmt->isStatic())
                 ->startLocation(new Location($stmt->getLine()))
                 ->endLocation(new Location($stmt->getEndLine()))

--- a/src/phpDocumentor/Reflection/Php/Factory/PropertyBuilder.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/PropertyBuilder.php
@@ -16,6 +16,7 @@ use phpDocumentor\Reflection\Php\Property as PropertyElement;
 use phpDocumentor\Reflection\Php\PropertyHook;
 use phpDocumentor\Reflection\Php\StrategyContainer;
 use phpDocumentor\Reflection\Php\Visibility;
+use phpDocumentor\Reflection\Types\Context;
 use PhpParser\Comment\Doc;
 use PhpParser\Modifiers;
 use PhpParser\Node;
@@ -163,7 +164,7 @@ final class PropertyBuilder
             $this->fqsen,
             $this->visibility,
             $this->docblock !== null ? $this->docBlockFactory->create($this->docblock->getText(), $context->getTypeContext()) : null,
-            $this->determineDefault(),
+            $this->determineDefault($context->getTypeContext()),
             $this->static,
             $this->startLocation,
             $this->endLocation,
@@ -346,9 +347,14 @@ final class PropertyBuilder
         };
     }
 
-    private function determineDefault(): Expression|null
+    private function determineDefault(Context|null $context): Expression|null
     {
-        $expression = $this->default !== null ? $this->valueConverter->prettyPrintExpr($this->default) : null;
+        if ($this->valueConverter instanceof ExpressionPrinter) {
+            $expression = $this->default !== null ? $this->valueConverter->prettyPrintExpr($this->default, $context) : null;
+        } else {
+            $expression = $this->default !== null ? $this->valueConverter->prettyPrintExpr($this->default) : null;
+        }
+
         if ($expression === null) {
             return null;
         }

--- a/src/phpDocumentor/Reflection/Php/Factory/PropertyBuilder.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/PropertyBuilder.php
@@ -9,6 +9,8 @@ use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Location;
 use phpDocumentor\Reflection\NodeVisitor\FindingVisitor;
 use phpDocumentor\Reflection\Php\AsymmetricVisibility;
+use phpDocumentor\Reflection\Php\Expression;
+use phpDocumentor\Reflection\Php\Expression\ExpressionPrinter;
 use phpDocumentor\Reflection\Php\Factory\Reducer\Reducer;
 use phpDocumentor\Reflection\Php\Property as PropertyElement;
 use phpDocumentor\Reflection\Php\PropertyHook;
@@ -26,11 +28,13 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Param;
 use PhpParser\Node\PropertyHook as PropertyHookNode;
 use PhpParser\NodeTraverser;
-use PhpParser\PrettyPrinter\Standard as PrettyPrinter;
+use PhpParser\PrettyPrinter;
+use PhpParser\PrettyPrinterAbstract;
 
 use function array_filter;
 use function array_map;
 use function count;
+use function is_string;
 use function method_exists;
 
 /**
@@ -56,7 +60,7 @@ final class PropertyBuilder
 
     /** @param iterable<Reducer> $reducers */
     private function __construct(
-        private PrettyPrinter $valueConverter,
+        private PrettyPrinter|PrettyPrinterAbstract $valueConverter,
         private DocBlockFactoryInterface $docBlockFactory,
         private StrategyContainer $strategies,
         private iterable $reducers,
@@ -66,7 +70,7 @@ final class PropertyBuilder
 
     /** @param iterable<Reducer> $reducers */
     public static function create(
-        PrettyPrinter $valueConverter,
+        PrettyPrinter|PrettyPrinterAbstract $valueConverter,
         DocBlockFactoryInterface $docBlockFactory,
         StrategyContainer $strategies,
         iterable $reducers,
@@ -159,7 +163,7 @@ final class PropertyBuilder
             $this->fqsen,
             $this->visibility,
             $this->docblock !== null ? $this->docBlockFactory->create($this->docblock->getText(), $context->getTypeContext()) : null,
-            $this->default !== null ? $this->valueConverter->prettyPrintExpr($this->default) : null,
+            $this->determineDefault(),
             $this->static,
             $this->startLocation,
             $this->endLocation,
@@ -340,5 +344,23 @@ final class PropertyBuilder
             'set' => $propertyVisibility->getWriteVisibility(),
             default => $propertyVisibility,
         };
+    }
+
+    private function determineDefault(): Expression|null
+    {
+        $expression = $this->default !== null ? $this->valueConverter->prettyPrintExpr($this->default) : null;
+        if ($expression === null) {
+            return null;
+        }
+
+        if ($this->valueConverter instanceof ExpressionPrinter) {
+            $expression = new Expression($expression, $this->valueConverter->getParts());
+        }
+
+        if (is_string($expression)) {
+            $expression = new Expression($expression, []);
+        }
+
+        return $expression;
     }
 }

--- a/src/phpDocumentor/Reflection/Php/Factory/Reducer/Parameter.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Reducer/Parameter.php
@@ -6,6 +6,8 @@ namespace phpDocumentor\Reflection\Php\Factory\Reducer;
 
 use Override;
 use phpDocumentor\Reflection\Php\Argument as ArgumentDescriptor;
+use phpDocumentor\Reflection\Php\Expression;
+use phpDocumentor\Reflection\Php\Expression\ExpressionPrinter;
 use phpDocumentor\Reflection\Php\Factory\ContextStack;
 use phpDocumentor\Reflection\Php\Factory\Type;
 use phpDocumentor\Reflection\Php\Function_;
@@ -14,6 +16,7 @@ use phpDocumentor\Reflection\Php\PropertyHook;
 use phpDocumentor\Reflection\Php\StrategyContainer;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Param;
 use PhpParser\PrettyPrinter\Standard as PrettyPrinter;
 use Webmozart\Assert\Assert;
 
@@ -47,7 +50,7 @@ class Parameter implements Reducer
                 new ArgumentDescriptor(
                     is_string($param->var->name) ? $param->var->name : $this->valueConverter->prettyPrintExpr($param->var->name),
                     (new Type())->fromPhpParser($param->type),
-                    $param->default !== null ? $this->valueConverter->prettyPrintExpr($param->default) : null,
+                    $this->determineDefault($param),
                     $param->byRef,
                     $param->variadic,
                 ),
@@ -55,5 +58,23 @@ class Parameter implements Reducer
         }
 
         return $carry;
+    }
+
+    private function determineDefault(Param $value): Expression|null
+    {
+        $expression = $value->default !== null ? $this->valueConverter->prettyPrintExpr($value->default) : null;
+        if ($expression === null) {
+            return null;
+        }
+
+        if ($this->valueConverter instanceof ExpressionPrinter) {
+            $expression = new Expression($expression, $this->valueConverter->getParts());
+        }
+
+        if (is_string($expression)) {
+            $expression = new Expression($expression, []);
+        }
+
+        return $expression;
     }
 }

--- a/src/phpDocumentor/Reflection/Php/Factory/Reducer/Parameter.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Reducer/Parameter.php
@@ -14,6 +14,7 @@ use phpDocumentor\Reflection\Php\Function_;
 use phpDocumentor\Reflection\Php\Method;
 use phpDocumentor\Reflection\Php\PropertyHook;
 use phpDocumentor\Reflection\Php\StrategyContainer;
+use phpDocumentor\Reflection\Types\Context;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Param;
@@ -50,7 +51,7 @@ class Parameter implements Reducer
                 new ArgumentDescriptor(
                     is_string($param->var->name) ? $param->var->name : $this->valueConverter->prettyPrintExpr($param->var->name),
                     (new Type())->fromPhpParser($param->type),
-                    $this->determineDefault($param),
+                    $this->determineDefault($param, $context->getTypeContext()),
                     $param->byRef,
                     $param->variadic,
                 ),
@@ -60,9 +61,14 @@ class Parameter implements Reducer
         return $carry;
     }
 
-    private function determineDefault(Param $value): Expression|null
+    private function determineDefault(Param $value, Context|null $context): Expression|null
     {
-        $expression = $value->default !== null ? $this->valueConverter->prettyPrintExpr($value->default) : null;
+        if ($this->valueConverter instanceof ExpressionPrinter) {
+            $expression = $value->default !== null ? $this->valueConverter->prettyPrintExpr($value->default, $context) : null;
+        } else {
+            $expression = $value->default !== null ? $this->valueConverter->prettyPrintExpr($value->default) : null;
+        }
+
         if ($expression === null) {
             return null;
         }

--- a/src/phpDocumentor/Reflection/Php/ProjectFactory.php
+++ b/src/phpDocumentor/Reflection/Php/ProjectFactory.php
@@ -18,6 +18,7 @@ use phpDocumentor\Reflection\DocBlockFactory;
 use phpDocumentor\Reflection\Exception;
 use phpDocumentor\Reflection\File as SourceFile;
 use phpDocumentor\Reflection\Fqsen;
+use phpDocumentor\Reflection\Php\Expression\ExpressionPrinter;
 use phpDocumentor\Reflection\Php\Factory\Class_;
 use phpDocumentor\Reflection\Php\Factory\ClassConstant;
 use phpDocumentor\Reflection\Php\Factory\ConstructorPromotion;
@@ -67,6 +68,7 @@ final class ProjectFactory implements ProjectFactoryInterface
     public static function createInstance(): self
     {
         $docblockFactory = DocBlockFactory::createInstance();
+        $expressionPrinter = new ExpressionPrinter();
 
         $attributeReducer = new Attribute();
         $parameterReducer = new Parameter(new PrettyPrinter());
@@ -86,7 +88,7 @@ final class ProjectFactory implements ProjectFactoryInterface
                 new Function_($docblockFactory, [$attributeReducer, $parameterReducer]),
                 new Interface_($docblockFactory, [$attributeReducer]),
                 $methodStrategy,
-                new Property($docblockFactory, new PrettyPrinter(), [$attributeReducer, $parameterReducer]),
+                new Property($docblockFactory, $expressionPrinter, [$attributeReducer, $parameterReducer]),
                 new Trait_($docblockFactory, [$attributeReducer]),
 
                 new IfStatement(),
@@ -95,7 +97,7 @@ final class ProjectFactory implements ProjectFactoryInterface
         );
 
         $strategies->addStrategy(
-            new ConstructorPromotion($methodStrategy, $docblockFactory, new PrettyPrinter(), [$attributeReducer, $parameterReducer]),
+            new ConstructorPromotion($methodStrategy, $docblockFactory, $expressionPrinter, [$attributeReducer, $parameterReducer]),
             1100,
         );
         $strategies->addStrategy(new Noop(), -PHP_INT_MAX);

--- a/src/phpDocumentor/Reflection/Php/ProjectFactory.php
+++ b/src/phpDocumentor/Reflection/Php/ProjectFactory.php
@@ -39,7 +39,6 @@ use phpDocumentor\Reflection\Php\Factory\Trait_;
 use phpDocumentor\Reflection\Php\Factory\TraitUse;
 use phpDocumentor\Reflection\Project as ProjectInterface;
 use phpDocumentor\Reflection\ProjectFactory as ProjectFactoryInterface;
-use PhpParser\PrettyPrinter\Standard as PrettyPrinter;
 
 use function is_array;
 

--- a/src/phpDocumentor/Reflection/Php/ProjectFactory.php
+++ b/src/phpDocumentor/Reflection/Php/ProjectFactory.php
@@ -70,7 +70,7 @@ final class ProjectFactory implements ProjectFactoryInterface
         $expressionPrinter = new ExpressionPrinter();
 
         $attributeReducer = new Attribute();
-        $parameterReducer = new Parameter(new PrettyPrinter());
+        $parameterReducer = new Parameter($expressionPrinter);
 
         $methodStrategy =  new Method($docblockFactory, [$attributeReducer, $parameterReducer]);
 
@@ -79,10 +79,10 @@ final class ProjectFactory implements ProjectFactoryInterface
                 new \phpDocumentor\Reflection\Php\Factory\Namespace_(),
                 new Class_($docblockFactory, [$attributeReducer]),
                 new Enum_($docblockFactory, [$attributeReducer]),
-                new EnumCase($docblockFactory, new PrettyPrinter(), [$attributeReducer]),
-                new Define($docblockFactory, new PrettyPrinter()),
-                new GlobalConstant($docblockFactory, new PrettyPrinter()),
-                new ClassConstant($docblockFactory, new PrettyPrinter(), [$attributeReducer]),
+                new EnumCase($docblockFactory, $expressionPrinter, [$attributeReducer]),
+                new Define($docblockFactory, $expressionPrinter),
+                new GlobalConstant($docblockFactory, $expressionPrinter),
+                new ClassConstant($docblockFactory, $expressionPrinter, [$attributeReducer]),
                 new Factory\File($docblockFactory, NodesFactory::createInstance()),
                 new Function_($docblockFactory, [$attributeReducer, $parameterReducer]),
                 new Interface_($docblockFactory, [$attributeReducer]),

--- a/src/phpDocumentor/Reflection/Php/Property.php
+++ b/src/phpDocumentor/Reflection/Php/Property.php
@@ -21,6 +21,11 @@ use phpDocumentor\Reflection\Location;
 use phpDocumentor\Reflection\Metadata\MetaDataContainer as MetaDataContainerInterface;
 use phpDocumentor\Reflection\Type;
 
+use function is_string;
+use function trigger_error;
+
+use const E_USER_DEPRECATED;
+
 /**
  * Descriptor representing a property.
  *

--- a/src/phpDocumentor/Reflection/Php/Property.php
+++ b/src/phpDocumentor/Reflection/Php/Property.php
@@ -66,14 +66,16 @@ final class Property implements Element, MetaDataContainerInterface, AttributeCo
         $this->location = $location ?: new Location(-1);
         $this->endLocation = $endLocation ?: new Location(-1);
 
-        if (is_string($this->default)) {
-            trigger_error(
-                'Default values for properties should be of type Expression, support for strings will be '
-                . 'removed in 7.x',
-                E_USER_DEPRECATED
-            );
-            $this->default = new Expression($this->default, []);
+        if (!is_string($this->default)) {
+            return;
         }
+
+        trigger_error(
+            'Default values for properties should be of type Expression, support for strings will be '
+            . 'removed in 7.x',
+            E_USER_DEPRECATED,
+        );
+        $this->default = new Expression($this->default, []);
     }
 
     /**
@@ -88,7 +90,7 @@ final class Property implements Element, MetaDataContainerInterface, AttributeCo
         if ($asString) {
             trigger_error(
                 'The Default value will become of type Expression by default',
-                E_USER_DEPRECATED
+                E_USER_DEPRECATED,
             );
 
             return (string) $this->default;

--- a/src/phpDocumentor/Reflection/Php/Property.php
+++ b/src/phpDocumentor/Reflection/Php/Property.php
@@ -76,6 +76,10 @@ final class Property implements Element, MetaDataContainerInterface, AttributeCo
      */
     public function getDefault(bool $asString = true): Expression|string|null
     {
+        if ($this->default === null) {
+            return null;
+        }
+
         if ($asString) {
             trigger_error(
                 'The Default value will become of type Expression by default',

--- a/src/phpDocumentor/Reflection/Php/Property.php
+++ b/src/phpDocumentor/Reflection/Php/Property.php
@@ -48,7 +48,7 @@ final class Property implements Element, MetaDataContainerInterface, AttributeCo
         private readonly Fqsen $fqsen,
         Visibility|null $visibility = null,
         private readonly DocBlock|null $docBlock = null,
-        private readonly string|null $default = null,
+        private Expression|string|null $default = null,
         private readonly bool $static = false,
         Location|null $location = null,
         Location|null $endLocation = null,
@@ -60,13 +60,31 @@ final class Property implements Element, MetaDataContainerInterface, AttributeCo
         $this->visibility = $visibility ?: new Visibility('public');
         $this->location = $location ?: new Location(-1);
         $this->endLocation = $endLocation ?: new Location(-1);
+
+        if (is_string($this->default)) {
+            trigger_error(
+                'Default values for properties should be of type Expression, support for strings will be '
+                . 'removed in 7.x',
+                E_USER_DEPRECATED
+            );
+            $this->default = new Expression($this->default, []);
+        }
     }
 
     /**
-     * returns the default value of this property.
+     * Returns the default value for this property.
      */
-    public function getDefault(): string|null
+    public function getDefault(bool $asString = true): Expression|string|null
     {
+        if ($asString) {
+            trigger_error(
+                'The Default value will become of type Expression by default',
+                E_USER_DEPRECATED
+            );
+
+            return (string) $this->default;
+        }
+
         return $this->default;
     }
 

--- a/tests/integration/FileDocblockTest.php
+++ b/tests/integration/FileDocblockTest.php
@@ -11,6 +11,8 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Integration tests to check the correct working of processing a namespace into a project.
+ *
+ * @coversNothing
  */
 #[CoversNothing]
 final class FileDocblockTest extends TestCase

--- a/tests/integration/PHP8/ConstructorPromotionTest.php
+++ b/tests/integration/PHP8/ConstructorPromotionTest.php
@@ -52,16 +52,27 @@ class ConstructorPromotionTest extends TestCase
 
         $constructor = $this->expectedConstructorMethod();
         $constructor->addArgument(new Argument('name', new String_(), "'default name'"));
-        $constructor->addArgument(new Argument('email', new Object_(new Fqsen('\\PHP8\\Email'))));
+        $constructor->addArgument(
+            new Argument(
+                'email',
+                new Object_(new Fqsen('\\PHP8\\Email')),
+                new Expression(
+                    'new {{ PHPDOCc27b34d4d91bc4d52190708db8447e09 }}()',
+                    [
+                        '{{ PHPDOCc27b34d4d91bc4d52190708db8447e09 }}' => new Fqsen('\\PHP8\\Email'),
+                    ],
+                )
+            )
+        );
         $constructor->addArgument(new Argument('birth_date', new Object_(new Fqsen('\\' . DateTimeImmutable::class))));
         $constructor->addArgument(
             new Argument(
                 'created_at',
                 new Object_(new Fqsen('\\' . DateTimeImmutable::class)),
                 new Expression(
-                    'new {{ PHPDOC6ffacd918e2f70478d2fd33dcb58c4d4 }}(\'now\')',
+                    'new {{ PHPDOCf854926c6ee2b49d3385c30295984295 }}(\'now\')',
                     [
-                        '{{ PHPDOC6ffacd918e2f70478d2fd33dcb58c4d4 }}' => new Fqsen('\\DateTimeImmutable')
+                        '{{ PHPDOCf854926c6ee2b49d3385c30295984295 }}' => new Fqsen('\\DateTimeImmutable')
                     ]
                 )
             )
@@ -73,7 +84,7 @@ class ConstructorPromotionTest extends TestCase
                 new Expression(
                     '[{{ PHPDOC19b72d1f430d952a8dfe2384dd4e93dc }}]',
                     [
-                        '{{ PHPDOC19b72d1f430d952a8dfe2384dd4e93dc }}' => new Fqsen('\PHP8\ConstructorPromotion::DEFAULT_VALUE'),
+                        '{{ PHPDOC19b72d1f430d952a8dfe2384dd4e93dc }}' => new Fqsen('\self::DEFAULT_VALUE'),
                     ],
                 ),
             ),
@@ -121,7 +132,7 @@ class ConstructorPromotionTest extends TestCase
             false,
             false,
             new Location(18, 264),
-            new Location(31, 704)
+            new Location(31, 718)
         );
     }
 
@@ -153,9 +164,9 @@ class ConstructorPromotionTest extends TestCase
             new Visibility(Visibility::PROTECTED_),
             null,
             new Expression(
-                'new {{PHPDOCce8ae9da5b7cd6c3df2929543a9af92d}}()',
+                'new {{ PHPDOCc27b34d4d91bc4d52190708db8447e09 }}()',
                 [
-                    '{{ PHPDOCce8ae9da5b7cd6c3df2929543a9af92d }}' => new Fqsen('\\PHP8\\Email'),
+                    '{{ PHPDOCc27b34d4d91bc4d52190708db8447e09 }}' => new Fqsen('\\PHP8\\Email'),
                 ],
             ),
             false,
@@ -186,9 +197,9 @@ class ConstructorPromotionTest extends TestCase
             new Visibility(Visibility::PRIVATE_),
             null,
             new Expression(
-                'new {{ PHPDOC6ffacd918e2f70478d2fd33dcb58c4d4 }}(\'now\')',
+                'new {{ PHPDOCf854926c6ee2b49d3385c30295984295 }}(\'now\')',
                 [
-                    '{{ PHPDOC6ffacd918e2f70478d2fd33dcb58c4d4 }}' => new Fqsen('\\DateTimeImmutable'),
+                    '{{ PHPDOCf854926c6ee2b49d3385c30295984295 }}' => new Fqsen('\\DateTimeImmutable'),
                 ],
             ),
             false,
@@ -207,7 +218,7 @@ class ConstructorPromotionTest extends TestCase
             new Expression(
                 '[{{ PHPDOC19b72d1f430d952a8dfe2384dd4e93dc }}]',
                 [
-                    '{{ PHPDOC19b72d1f430d952a8dfe2384dd4e93dc }}' => new Fqsen('\PHP8\ConstructorPromotion::DEFAULT_VALUE'),
+                    '{{ PHPDOC19b72d1f430d952a8dfe2384dd4e93dc }}' => new Fqsen('\self::DEFAULT_VALUE'),
                 ],
             ),
             false,

--- a/tests/integration/PHP8/ConstructorPromotionTest.php
+++ b/tests/integration/PHP8/ConstructorPromotionTest.php
@@ -13,6 +13,7 @@ use phpDocumentor\Reflection\File\LocalFile;
 use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Location;
 use phpDocumentor\Reflection\Php\Argument;
+use phpDocumentor\Reflection\Php\Expression;
 use phpDocumentor\Reflection\Php\Method;
 use phpDocumentor\Reflection\Php\ProjectFactory;
 use phpDocumentor\Reflection\Php\Project;
@@ -29,12 +30,10 @@ use PHPUnit\Framework\TestCase;
  */
 class ConstructorPromotionTest extends TestCase
 {
-    const FILE = __DIR__ . '/../data/PHP8/ConstructorPromotion.php';
-    /** @var ProjectFactory */
-    private $fixture;
+    private const FILE = __DIR__ . '/../data/PHP8/ConstructorPromotion.php';
 
-    /** @var Project */
-    private $project;
+    private ProjectFactory $fixture;
+    private Project $project;
 
     protected function setUp() : void
     {
@@ -56,8 +55,6 @@ class ConstructorPromotionTest extends TestCase
         $constructor->addArgument(new Argument('name', new String_(), "'default name'"));
         $constructor->addArgument(new Argument('email', new Object_(new Fqsen('\\PHP8\\Email'))));
         $constructor->addArgument(new Argument('birth_date', new Object_(new Fqsen('\\' . DateTimeImmutable::class))));
-        $constructor->addArgument(new Argument('created_at', new Object_(new Fqsen('\\' . DateTimeImmutable::class))));
-        $constructor->addArgument(new Argument('uses_constants', new Array_()));
 
         self::assertEquals($constructor, $class->getMethods()['\PHP8\ConstructorPromotion::__construct()']);
         self::assertEquals(
@@ -65,8 +62,6 @@ class ConstructorPromotionTest extends TestCase
                 '\PHP8\ConstructorPromotion::$name' => $this->expectedNameProperty(),
                 '\PHP8\ConstructorPromotion::$email' => $this->expectedEmailProperty(),
                 '\PHP8\ConstructorPromotion::$birth_date' => $this->expectedBirthDateProperty(),
-                '\PHP8\ConstructorPromotion::$created_at' => $this->expectedCreatedAtProperty(),
-                '\PHP8\ConstructorPromotion::$uses_constants' => $this->expectedUsesConstantsProperty(),
             ],
             $class->getProperties()
         );
@@ -93,14 +88,14 @@ class ConstructorPromotionTest extends TestCase
             false,
             false,
             false,
-            new Location(18, 218),
-            new Location(31, 522)
+            new Location(18, 264),
+            new Location(29, 568)
         );
     }
 
     private function expectedNameProperty(): Property
     {
-        $name = new Property(
+        return new Property(
             new Fqsen('\PHP8\ConstructorPromotion::$name'),
             new Visibility(Visibility::PUBLIC_),
             new DocBlock(
@@ -113,68 +108,37 @@ class ConstructorPromotionTest extends TestCase
             ),
             "'default name'",
             false,
-            new Location(24, 393),
-            new Location(24, 428),
+            new Location(26, 393),
+            new Location(26, 428),
             new String_()
         );
-        return $name;
     }
 
     private function expectedEmailProperty(): Property
     {
-        $email = new Property(
+        return new Property(
             new Fqsen('\PHP8\ConstructorPromotion::$email'),
             new Visibility(Visibility::PROTECTED_),
             null,
             null,
             false,
-            new Location(25, 439),
-            new Location(25, 460),
+            new Location(27, 439),
+            new Location(27, 460),
             new Object_(new Fqsen('\\PHP8\\Email'))
         );
-        return $email;
     }
 
     private function expectedBirthDateProperty(): Property
     {
-        $birthDate = new Property(
+        return new Property(
             new Fqsen('\PHP8\ConstructorPromotion::$birth_date'),
             new Visibility(Visibility::PRIVATE_),
             null,
             null,
             false,
-            new Location(26),
-            new Location(26),
+            new Location(28),
+            new Location(28),
             new Object_(new Fqsen('\\' . DateTimeImmutable::class))
-        );
-        return $birthDate;
-    }
-
-    private function expectedCreatedAtProperty(): Property
-    {
-        return new Property(
-            new Fqsen('\PHP8\ConstructorPromotion::$created_at'),
-            new Visibility(Visibility::PRIVATE_),
-            null,
-            null,
-            false,
-            new Location(26),
-            new Location(26),
-            new Object_(new Fqsen('\\' . DateTimeImmutable::class))
-        );
-    }
-
-    private function expectedUsesConstantsProperty(): Property
-    {
-        return new Property(
-            new Fqsen('\PHP8\ConstructorPromotion::$uses_constants'),
-            new Visibility(Visibility::PRIVATE_),
-            null,
-            null,
-            false,
-            new Location(26),
-            new Location(26),
-            new Array_()
         );
     }
 }

--- a/tests/integration/PHP8/ConstructorPromotionTest.php
+++ b/tests/integration/PHP8/ConstructorPromotionTest.php
@@ -46,7 +46,7 @@ class ConstructorPromotionTest extends TestCase
         );
     }
 
-    public function testPropertiesAreCreated() : void
+    public function testArgumentsAreReadCorrectly() : void
     {
         $file = $this->project->getFiles()[self::FILE];
         $class = $file->getClasses()['\\PHP8\\ConstructorPromotion'];
@@ -55,13 +55,45 @@ class ConstructorPromotionTest extends TestCase
         $constructor->addArgument(new Argument('name', new String_(), "'default name'"));
         $constructor->addArgument(new Argument('email', new Object_(new Fqsen('\\PHP8\\Email'))));
         $constructor->addArgument(new Argument('birth_date', new Object_(new Fqsen('\\' . DateTimeImmutable::class))));
+        $constructor->addArgument(
+            new Argument(
+                'created_at',
+                new Object_(new Fqsen('\\' . DateTimeImmutable::class)),
+                new Expression(
+                    'new {{ PHPDOC6ffacd918e2f70478d2fd33dcb58c4d4 }}(\'now\')',
+                    [
+                        '{{ PHPDOC6ffacd918e2f70478d2fd33dcb58c4d4 }}' => new Fqsen('\\DateTimeImmutable')
+                    ]
+                )
+            )
+        );
+        $constructor->addArgument(
+            new Argument(
+                'uses_constants',
+                new Array_(),
+                new Expression(
+                    '[{{ PHPDOC590f53e8699817c6fa498cc11a4cbe63 }}]',
+                    [
+                        '{{ PHPDOC590f53e8699817c6fa498cc11a4cbe63 }}' => new Fqsen('\PHP8\ConstructorPromotion::DEFAULT_VALUE')
+                    ]
+                )
+            )
+        );
 
         self::assertEquals($constructor, $class->getMethods()['\PHP8\ConstructorPromotion::__construct()']);
+    }
+
+    public function testPropertiesAreCreated() : void
+    {
+        $file = $this->project->getFiles()[self::FILE];
+        $class = $file->getClasses()['\\PHP8\\ConstructorPromotion'];
+
         self::assertEquals(
             [
                 '\PHP8\ConstructorPromotion::$name' => $this->expectedNameProperty(),
                 '\PHP8\ConstructorPromotion::$email' => $this->expectedEmailProperty(),
                 '\PHP8\ConstructorPromotion::$birth_date' => $this->expectedBirthDateProperty(),
+                '\PHP8\ConstructorPromotion::$created_at' => $this->expectedCreatedAtProperty(),
             ],
             $class->getProperties()
         );
@@ -89,7 +121,7 @@ class ConstructorPromotionTest extends TestCase
             false,
             false,
             new Location(18, 264),
-            new Location(29, 568)
+            new Location(31, 709)
         );
     }
 
@@ -138,6 +170,25 @@ class ConstructorPromotionTest extends TestCase
             false,
             new Location(28),
             new Location(28),
+            new Object_(new Fqsen('\\' . DateTimeImmutable::class))
+        );
+    }
+
+    private function expectedCreatedAtProperty(): Property
+    {
+        return new Property(
+            new Fqsen('\PHP8\ConstructorPromotion::$created_at'),
+            new Visibility(Visibility::PRIVATE_),
+            null,
+            new Expression(
+                'new {{ PHPDOC6ffacd918e2f70478d2fd33dcb58c4d4 }}(\'now\')',
+                [
+                    '{{ PHPDOC6ffacd918e2f70478d2fd33dcb58c4d4 }}' => new Fqsen('\\DateTimeImmutable')
+                ]
+            ),
+            false,
+            new Location(29),
+            new Location(29),
             new Object_(new Fqsen('\\' . DateTimeImmutable::class))
         );
     }

--- a/tests/integration/PHP8/ConstructorPromotionTest.php
+++ b/tests/integration/PHP8/ConstructorPromotionTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace integration\PHP8;
 
 use DateTimeImmutable;
-use DateTimeImmutable;
 use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\DocBlock\Tags\Param;
 use phpDocumentor\Reflection\DocBlock\Tags\Var_;
@@ -15,8 +14,8 @@ use phpDocumentor\Reflection\Location;
 use phpDocumentor\Reflection\Php\Argument;
 use phpDocumentor\Reflection\Php\Expression;
 use phpDocumentor\Reflection\Php\Method;
-use phpDocumentor\Reflection\Php\ProjectFactory;
 use phpDocumentor\Reflection\Php\Project;
+use phpDocumentor\Reflection\Php\ProjectFactory;
 use phpDocumentor\Reflection\Php\Property;
 use phpDocumentor\Reflection\Php\Visibility;
 use phpDocumentor\Reflection\Types\Array_;
@@ -51,7 +50,7 @@ class ConstructorPromotionTest extends TestCase
         $file = $this->project->getFiles()[self::FILE];
         $class = $file->getClasses()['\\PHP8\\ConstructorPromotion'];
 
-        $constructor = $this->expectedContructorMethod();
+        $constructor = $this->expectedConstructorMethod();
         $constructor->addArgument(new Argument('name', new String_(), "'default name'"));
         $constructor->addArgument(new Argument('email', new Object_(new Fqsen('\\PHP8\\Email'))));
         $constructor->addArgument(new Argument('birth_date', new Object_(new Fqsen('\\' . DateTimeImmutable::class))));
@@ -72,12 +71,12 @@ class ConstructorPromotionTest extends TestCase
                 'uses_constants',
                 new Array_(),
                 new Expression(
-                    '[{{ PHPDOC590f53e8699817c6fa498cc11a4cbe63 }}]',
+                    '[{{ PHPDOC19b72d1f430d952a8dfe2384dd4e93dc }}]',
                     [
-                        '{{ PHPDOC590f53e8699817c6fa498cc11a4cbe63 }}' => new Fqsen('\PHP8\ConstructorPromotion::DEFAULT_VALUE')
-                    ]
-                )
-            )
+                        '{{ PHPDOC19b72d1f430d952a8dfe2384dd4e93dc }}' => new Fqsen('\PHP8\ConstructorPromotion::DEFAULT_VALUE'),
+                    ],
+                ),
+            ),
         );
 
         self::assertEquals($constructor, $class->getMethods()['\PHP8\ConstructorPromotion::__construct()']);
@@ -94,6 +93,7 @@ class ConstructorPromotionTest extends TestCase
                 '\PHP8\ConstructorPromotion::$email' => $this->expectedEmailProperty(),
                 '\PHP8\ConstructorPromotion::$birth_date' => $this->expectedBirthDateProperty(),
                 '\PHP8\ConstructorPromotion::$created_at' => $this->expectedCreatedAtProperty(),
+                '\PHP8\ConstructorPromotion::$uses_constants' => $this->expectedUsesConstantsProperty(),
             ],
             $class->getProperties()
         );
@@ -121,7 +121,7 @@ class ConstructorPromotionTest extends TestCase
             false,
             false,
             new Location(18, 264),
-            new Location(31, 709)
+            new Location(31, 704)
         );
     }
 
@@ -140,8 +140,8 @@ class ConstructorPromotionTest extends TestCase
             ),
             "'default name'",
             false,
-            new Location(26, 393),
-            new Location(26, 428),
+            new Location(26),
+            new Location(26),
             new String_()
         );
     }
@@ -152,11 +152,16 @@ class ConstructorPromotionTest extends TestCase
             new Fqsen('\PHP8\ConstructorPromotion::$email'),
             new Visibility(Visibility::PROTECTED_),
             null,
-            null,
+            new Expression(
+                'new {{PHPDOCce8ae9da5b7cd6c3df2929543a9af92d}}()',
+                [
+                    '{{ PHPDOCce8ae9da5b7cd6c3df2929543a9af92d }}' => new Fqsen('\\PHP8\\Email'),
+                ],
+            ),
             false,
-            new Location(27, 439),
-            new Location(27, 460),
-            new Object_(new Fqsen('\\PHP8\\Email'))
+            new Location(27),
+            new Location(27),
+            New Object_(new Fqsen('\\PHP8\\Email')),
         );
     }
 
@@ -183,13 +188,32 @@ class ConstructorPromotionTest extends TestCase
             new Expression(
                 'new {{ PHPDOC6ffacd918e2f70478d2fd33dcb58c4d4 }}(\'now\')',
                 [
-                    '{{ PHPDOC6ffacd918e2f70478d2fd33dcb58c4d4 }}' => new Fqsen('\\DateTimeImmutable')
-                ]
+                    '{{ PHPDOC6ffacd918e2f70478d2fd33dcb58c4d4 }}' => new Fqsen('\\DateTimeImmutable'),
+                ],
             ),
             false,
             new Location(29),
             new Location(29),
-            new Object_(new Fqsen('\\' . DateTimeImmutable::class))
+            new Object_(new Fqsen('\\' . DateTimeImmutable::class)),
+        );
+    }
+
+    private function expectedUsesConstantsProperty()
+    {
+        return new Property(
+            new Fqsen('\PHP8\ConstructorPromotion::$uses_constants'),
+            new Visibility(Visibility::PRIVATE_),
+            null,
+            new Expression(
+                '[{{ PHPDOC19b72d1f430d952a8dfe2384dd4e93dc }}]',
+                [
+                    '{{ PHPDOC19b72d1f430d952a8dfe2384dd4e93dc }}' => new Fqsen('\PHP8\ConstructorPromotion::DEFAULT_VALUE'),
+                ],
+            ),
+            false,
+            new Location(30),
+            new Location(30),
+            new Array_(),
         );
     }
 }

--- a/tests/integration/PHP8/ConstructorPromotionTest.php
+++ b/tests/integration/PHP8/ConstructorPromotionTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace integration\PHP8;
 
+use DateTimeImmutable;
+use DateTimeImmutable;
 use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\DocBlock\Tags\Param;
 use phpDocumentor\Reflection\DocBlock\Tags\Var_;
@@ -16,6 +18,7 @@ use phpDocumentor\Reflection\Php\ProjectFactory;
 use phpDocumentor\Reflection\Php\Project;
 use phpDocumentor\Reflection\Php\Property;
 use phpDocumentor\Reflection\Php\Visibility;
+use phpDocumentor\Reflection\Types\Array_;
 use phpDocumentor\Reflection\Types\Context;
 use phpDocumentor\Reflection\Types\Object_;
 use phpDocumentor\Reflection\Types\String_;
@@ -52,22 +55,26 @@ class ConstructorPromotionTest extends TestCase
         $constructor = $this->expectedContructorMethod();
         $constructor->addArgument(new Argument('name', new String_(), "'default name'"));
         $constructor->addArgument(new Argument('email', new Object_(new Fqsen('\\PHP8\\Email'))));
-        $constructor->addArgument(new Argument('birth_date', new Object_(new Fqsen('\\' . \DateTimeImmutable::class))));
+        $constructor->addArgument(new Argument('birth_date', new Object_(new Fqsen('\\' . DateTimeImmutable::class))));
+        $constructor->addArgument(new Argument('created_at', new Object_(new Fqsen('\\' . DateTimeImmutable::class))));
+        $constructor->addArgument(new Argument('uses_constants', new Array_()));
 
         self::assertEquals($constructor, $class->getMethods()['\PHP8\ConstructorPromotion::__construct()']);
         self::assertEquals(
             [
                 '\PHP8\ConstructorPromotion::$name' => $this->expectedNameProperty(),
                 '\PHP8\ConstructorPromotion::$email' => $this->expectedEmailProperty(),
-                '\PHP8\ConstructorPromotion::$birth_date' => $this->expectedBirthDateProperty()
+                '\PHP8\ConstructorPromotion::$birth_date' => $this->expectedBirthDateProperty(),
+                '\PHP8\ConstructorPromotion::$created_at' => $this->expectedCreatedAtProperty(),
+                '\PHP8\ConstructorPromotion::$uses_constants' => $this->expectedUsesConstantsProperty(),
             ],
             $class->getProperties()
         );
     }
 
-    private function expectedContructorMethod(): Method
+    private function expectedConstructorMethod(): Method
     {
-        $constructor = new Method(
+        return new Method(
             new Fqsen('\PHP8\ConstructorPromotion::__construct()'),
             new Visibility(Visibility::PUBLIC_),
             new DocBlock(
@@ -86,10 +93,9 @@ class ConstructorPromotionTest extends TestCase
             false,
             false,
             false,
-            new Location(16, 218),
-            new Location(27, 517)
+            new Location(18, 218),
+            new Location(31, 522)
         );
-        return $constructor;
     }
 
     private function expectedNameProperty(): Property
@@ -137,10 +143,38 @@ class ConstructorPromotionTest extends TestCase
             null,
             null,
             false,
-            new Location(26, 471),
-            new Location(26, 507),
-            new Object_(new Fqsen('\\' . \DateTimeImmutable::class))
+            new Location(26),
+            new Location(26),
+            new Object_(new Fqsen('\\' . DateTimeImmutable::class))
         );
         return $birthDate;
+    }
+
+    private function expectedCreatedAtProperty(): Property
+    {
+        return new Property(
+            new Fqsen('\PHP8\ConstructorPromotion::$created_at'),
+            new Visibility(Visibility::PRIVATE_),
+            null,
+            null,
+            false,
+            new Location(26),
+            new Location(26),
+            new Object_(new Fqsen('\\' . DateTimeImmutable::class))
+        );
+    }
+
+    private function expectedUsesConstantsProperty(): Property
+    {
+        return new Property(
+            new Fqsen('\PHP8\ConstructorPromotion::$uses_constants'),
+            new Visibility(Visibility::PRIVATE_),
+            null,
+            null,
+            false,
+            new Location(26),
+            new Location(26),
+            new Array_()
+        );
     }
 }

--- a/tests/integration/data/PHP8/ConstructorPromotion.php
+++ b/tests/integration/data/PHP8/ConstructorPromotion.php
@@ -26,7 +26,5 @@ class ConstructorPromotion
         public string $name = 'default name',
         protected Email $email,
         private DateTimeImmutable $birth_date,
-        private DateTimeImmutable $created_at = new DateTimeImmutable('now'),
-        private array $uses_constants = [self::DEFAULT_VALUE],
     ) {}
 }

--- a/tests/integration/data/PHP8/ConstructorPromotion.php
+++ b/tests/integration/data/PHP8/ConstructorPromotion.php
@@ -8,6 +8,8 @@ use DateTimeImmutable;
 
 class ConstructorPromotion
 {
+    private const DEFAULT_VALUE = 'default';
+
     /**
      * Constructor with promoted properties
      *
@@ -24,5 +26,7 @@ class ConstructorPromotion
         public string $name = 'default name',
         protected Email $email,
         private DateTimeImmutable $birth_date,
+        private DateTimeImmutable $created_at = new DateTimeImmutable('now'),
+        private array $uses_constants = [self::DEFAULT_VALUE],
     ) {}
 }

--- a/tests/integration/data/PHP8/ConstructorPromotion.php
+++ b/tests/integration/data/PHP8/ConstructorPromotion.php
@@ -26,5 +26,7 @@ class ConstructorPromotion
         public string $name = 'default name',
         protected Email $email,
         private DateTimeImmutable $birth_date,
+        private DateTimeImmutable $created_at = new DateTimeImmutable('now'),
+        private array $uses_constants = [self::DEFAULT_VALUE],
     ) {}
 }

--- a/tests/integration/data/PHP8/ConstructorPromotion.php
+++ b/tests/integration/data/PHP8/ConstructorPromotion.php
@@ -24,7 +24,7 @@ class ConstructorPromotion
          * @var string $name property description
          */
         public string $name = 'default name',
-        protected Email $email,
+        protected Email $email = new Email(),
         private DateTimeImmutable $birth_date,
         private DateTimeImmutable $created_at = new DateTimeImmutable('now'),
         private array $uses_constants = [self::DEFAULT_VALUE],

--- a/tests/unit/phpDocumentor/Reflection/Php/ArgumentTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/ArgumentTest.php
@@ -26,49 +26,50 @@ final class ArgumentTest extends TestCase
 {
     public function testGetTypes(): void
     {
-        $argument = new Argument('myArgument', null, 'myDefaultValue', true, true);
-        $this->assertInstanceOf(Mixed_::class, $argument->getType());
+        $argument = new Argument('myArgument', null, new Expression('myDefaultValue'), true, true);
+        self::assertInstanceOf(Mixed_::class, $argument->getType());
 
         $argument = new Argument(
             'myArgument',
             new String_(),
-            'myDefaultValue',
+            new Expression('myDefaultValue'),
             true,
             true,
         );
-        $this->assertEquals(new String_(), $argument->getType());
+        self::assertEquals(new String_(), $argument->getType());
     }
 
     public function testGetName(): void
     {
-        $argument = new Argument('myArgument', null, 'myDefault', true, true);
-        $this->assertEquals('myArgument', $argument->getName());
+        $argument = new Argument('myArgument', null, new Expression('myDefault'), true, true);
+
+        self::assertEquals('myArgument', $argument->getName());
     }
 
     public function testGetDefault(): void
     {
-        $argument = new Argument('myArgument', null, 'myDefaultValue', true, true);
-        $this->assertEquals('myDefaultValue', $argument->getDefault());
+        $argument = new Argument('myArgument', null, new Expression('myDefaultValue'), true, true);
+        self::assertEquals(new Expression('myDefaultValue'), $argument->getDefault());
 
         $argument = new Argument('myArgument', null, null, true, true);
-        $this->assertNull($argument->getDefault());
+        self::assertNull($argument->getDefault());
     }
 
     public function testGetWhetherArgumentIsPassedByReference(): void
     {
-        $argument = new Argument('myArgument', null, 'myDefaultValue', true, true);
-        $this->assertTrue($argument->isByReference());
+        $argument = new Argument('myArgument', null, new Expression('myDefaultValue'), true, true);
+        self::assertTrue($argument->isByReference());
 
         $argument = new Argument('myArgument', null, null, false, true);
-        $this->assertFalse($argument->isByReference());
+        self::assertFalse($argument->isByReference());
     }
 
     public function testGetWhetherArgumentisVariadic(): void
     {
-        $argument = new Argument('myArgument', null, 'myDefaultValue', true, true);
-        $this->assertTrue($argument->isVariadic());
+        $argument = new Argument('myArgument', null, new Expression('myDefaultValue'), true, true);
+        self::assertTrue($argument->isVariadic());
 
-        $argument = new Argument('myArgument', null, 'myDefaultValue', true, false);
-        $this->assertFalse($argument->isVariadic());
+        $argument = new Argument('myArgument', null, new Expression('myDefaultValue'), true, false);
+        self::assertFalse($argument->isVariadic());
     }
 }

--- a/tests/unit/phpDocumentor/Reflection/Php/ConstantTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/ConstantTest.php
@@ -42,7 +42,7 @@ final class ConstantTest extends TestCase
     {
         $this->fqsen = new Fqsen('\MySpace\CONSTANT');
         $this->docBlock = new DocBlock('');
-        $this->fixture = new Constant($this->fqsen, $this->docBlock, $this->value);
+        $this->fixture = new Constant($this->fqsen, $this->docBlock, new Expression($this->value));
     }
 
     private function getFixture(): MetaDataContainerInterface
@@ -52,28 +52,28 @@ final class ConstantTest extends TestCase
 
     public function testGetValue(): void
     {
-        $this->assertSame($this->value, $this->fixture->getValue());
+        self::assertEquals(new Expression($this->value), $this->fixture->getValue());
     }
 
     public function testIsFinal(): void
     {
-        $this->assertFalse($this->fixture->isFinal());
+        self::assertFalse($this->fixture->isFinal());
     }
 
     public function testGetFqsen(): void
     {
-        $this->assertSame($this->fqsen, $this->fixture->getFqsen());
-        $this->assertSame($this->fqsen->getName(), $this->fixture->getName());
+        self::assertSame($this->fqsen, $this->fixture->getFqsen());
+        self::assertSame($this->fqsen->getName(), $this->fixture->getName());
     }
 
     public function testGetDocblock(): void
     {
-        $this->assertSame($this->docBlock, $this->fixture->getDocBlock());
+        self::assertSame($this->docBlock, $this->fixture->getDocBlock());
     }
 
     public function testGetVisibility(): void
     {
-        $this->assertEquals(new Visibility(Visibility::PUBLIC_), $this->fixture->getVisibility());
+        self::assertEquals(new Visibility(Visibility::PUBLIC_), $this->fixture->getVisibility());
     }
 
     public function testLineAndColumnNumberIsReturnedWhenALocationIsProvided(): void

--- a/tests/unit/phpDocumentor/Reflection/Php/EnumCaseTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/EnumCaseTest.php
@@ -32,14 +32,18 @@ final class EnumCaseTest extends TestCase
     private DocBlock $docBlock;
 
     /**
-     * Creates a new (emoty) fixture object.
+     * Creates a new (empty) fixture object.
      */
     protected function setUp(): void
     {
         $this->fqsen    = new Fqsen('\Enum::VALUE');
         $this->docBlock = new DocBlock('');
 
-        $this->fixture = new EnumCase($this->fqsen, $this->docBlock);
+        // needed for MetaDataContainer testing
+        $this->fixture = new EnumCase(
+            $this->fqsen,
+            $this->docBlock,
+        );
     }
 
     private function getFixture(): MetaDataContainerInterface
@@ -49,26 +53,141 @@ final class EnumCaseTest extends TestCase
 
     public function testGettingName(): void
     {
-        $this->assertSame($this->fqsen->getName(), $this->fixture->getName());
+        $fixture = new EnumCase(
+            $this->fqsen,
+            $this->docBlock,
+        );
+
+        $this->assertSame($this->fqsen->getName(), $fixture->getName());
     }
 
     public function testGettingFqsen(): void
     {
-        $this->assertSame($this->fqsen, $this->fixture->getFqsen());
+        $fixture = new EnumCase(
+            $this->fqsen,
+            $this->docBlock,
+        );
+
+        $this->assertSame($this->fqsen, $fixture->getFqsen());
     }
 
     public function testGettingDocBlock(): void
     {
-        $this->assertSame($this->docBlock, $this->fixture->getDocBlock());
+        $fixture = new EnumCase(
+            $this->fqsen,
+            $this->docBlock,
+        );
+
+        $this->assertSame($this->docBlock, $fixture->getDocBlock());
     }
 
-    public function testGetValue(): void
+    /**
+     * @covers ::getValue
+     */
+    public function testValueCanBeOmitted(): void
     {
-        $this->assertNull($this->fixture->getValue());
+        $fixture = new EnumCase(
+            $this->fqsen,
+            $this->docBlock,
+        );
+
+        $this->assertNull($fixture->getValue());
     }
 
-    public function testGetLocationReturnsDefault(): void
+    /**
+     * @uses Expression
+     *
+     * @covers ::getValue
+     */
+    public function testValueCanBeProvidedAsAnExpression(): void
     {
-        self::assertEquals(new Location(-1), $this->fixture->getLocation());
+        $expression = new Expression('Enum case expression');
+        $fixture = new EnumCase(
+            $this->fqsen,
+            $this->docBlock,
+            null,
+            null,
+            $expression,
+        );
+
+        $this->assertSame($expression, $fixture->getValue(false));
+    }
+
+    /**
+     * @uses Expression
+     *
+     * @covers ::getValue
+     */
+    public function testValueCanBeReturnedAsString(): void
+    {
+        $expression = new Expression('Enum case expression');
+        $fixture = new EnumCase(
+            $this->fqsen,
+            $this->docBlock,
+            null,
+            null,
+            $expression,
+        );
+
+        $this->assertSame('Enum case expression', $fixture->getValue(true));
+    }
+
+    /**
+     * @covers ::getLocation
+     */
+    public function testGetLocationReturnsProvidedValue(): void
+    {
+        $location = new Location(15, 10);
+        $fixture = new EnumCase(
+            $this->fqsen,
+            $this->docBlock,
+            $location,
+        );
+
+        self::assertSame($location, $fixture->getLocation());
+    }
+
+    /**
+     * @uses Location
+     *
+     * @covers ::getLocation
+     */
+    public function testGetLocationReturnsUnknownByDefault(): void
+    {
+        $fixture = new EnumCase(
+            $this->fqsen,
+            $this->docBlock,
+        );
+
+        self::assertEquals(new Location(-1), $fixture->getLocation());
+    }
+
+    /**
+     * @covers ::getEndLocation
+     */
+    public function testGetEndLocationReturnsProvidedValue(): void
+    {
+        $location = new Location(11, 23);
+        $fixture = new EnumCase(
+            $this->fqsen,
+            $this->docBlock,
+            null,
+            $location,
+        );
+
+        self::assertSame($location, $fixture->getEndLocation());
+    }
+
+    /**
+     * @covers ::getEndLocation
+     */
+    public function testGetEndLocationReturnsUnknownByDefault(): void
+    {
+        $fixture = new EnumCase(
+            $this->fqsen,
+            $this->docBlock,
+        );
+
+        self::assertEquals(new Location(-1), $fixture->getEndLocation());
     }
 }

--- a/tests/unit/phpDocumentor/Reflection/Php/EnumCaseTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/EnumCaseTest.php
@@ -81,9 +81,7 @@ final class EnumCaseTest extends TestCase
         $this->assertSame($this->docBlock, $fixture->getDocBlock());
     }
 
-    /**
-     * @covers ::getValue
-     */
+    /** @covers ::getValue */
     public function testValueCanBeOmitted(): void
     {
         $fixture = new EnumCase(
@@ -132,9 +130,7 @@ final class EnumCaseTest extends TestCase
         $this->assertSame('Enum case expression', $fixture->getValue(true));
     }
 
-    /**
-     * @covers ::getLocation
-     */
+    /** @covers ::getLocation */
     public function testGetLocationReturnsProvidedValue(): void
     {
         $location = new Location(15, 10);
@@ -162,9 +158,7 @@ final class EnumCaseTest extends TestCase
         self::assertEquals(new Location(-1), $fixture->getLocation());
     }
 
-    /**
-     * @covers ::getEndLocation
-     */
+    /** @covers ::getEndLocation */
     public function testGetEndLocationReturnsProvidedValue(): void
     {
         $location = new Location(11, 23);
@@ -178,9 +172,7 @@ final class EnumCaseTest extends TestCase
         self::assertSame($location, $fixture->getEndLocation());
     }
 
-    /**
-     * @covers ::getEndLocation
-     */
+    /** @covers ::getEndLocation */
     public function testGetEndLocationReturnsUnknownByDefault(): void
     {
         $fixture = new EnumCase(

--- a/tests/unit/phpDocumentor/Reflection/Php/EnumCaseTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/EnumCaseTest.php
@@ -81,7 +81,6 @@ final class EnumCaseTest extends TestCase
         $this->assertSame($this->docBlock, $fixture->getDocBlock());
     }
 
-    /** @covers ::getValue */
     public function testValueCanBeOmitted(): void
     {
         $fixture = new EnumCase(
@@ -92,11 +91,6 @@ final class EnumCaseTest extends TestCase
         $this->assertNull($fixture->getValue());
     }
 
-    /**
-     * @uses Expression
-     *
-     * @covers ::getValue
-     */
     public function testValueCanBeProvidedAsAnExpression(): void
     {
         $expression = new Expression('Enum case expression');
@@ -111,11 +105,6 @@ final class EnumCaseTest extends TestCase
         $this->assertSame($expression, $fixture->getValue(false));
     }
 
-    /**
-     * @uses Expression
-     *
-     * @covers ::getValue
-     */
     public function testValueCanBeReturnedAsString(): void
     {
         $expression = new Expression('Enum case expression');
@@ -130,7 +119,6 @@ final class EnumCaseTest extends TestCase
         $this->assertSame('Enum case expression', $fixture->getValue(true));
     }
 
-    /** @covers ::getLocation */
     public function testGetLocationReturnsProvidedValue(): void
     {
         $location = new Location(15, 10);
@@ -143,11 +131,6 @@ final class EnumCaseTest extends TestCase
         self::assertSame($location, $fixture->getLocation());
     }
 
-    /**
-     * @uses Location
-     *
-     * @covers ::getLocation
-     */
     public function testGetLocationReturnsUnknownByDefault(): void
     {
         $fixture = new EnumCase(
@@ -158,7 +141,6 @@ final class EnumCaseTest extends TestCase
         self::assertEquals(new Location(-1), $fixture->getLocation());
     }
 
-    /** @covers ::getEndLocation */
     public function testGetEndLocationReturnsProvidedValue(): void
     {
         $location = new Location(11, 23);
@@ -172,7 +154,6 @@ final class EnumCaseTest extends TestCase
         self::assertSame($location, $fixture->getEndLocation());
     }
 
-    /** @covers ::getEndLocation */
     public function testGetEndLocationReturnsUnknownByDefault(): void
     {
         $fixture = new EnumCase(

--- a/tests/unit/phpDocumentor/Reflection/Php/ExpressionTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/ExpressionTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Reflection\Php;
+
+use InvalidArgumentException;
+use phpDocumentor\Reflection\Fqsen;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+/**
+ * @coversDefaultClass Expression
+ * @covers ::__construct
+ * @covers ::<private>
+ */
+final class ExpressionTest extends TestCase
+{
+    private const EXAMPLE_FQSEN = '\\' . self::class;
+    private const EXAMPLE_FQSEN_PLACEHOLDER = '{{ PHPDOC0450ed2a7bac1efcf0c13b6560767954 }}';
+
+    /**
+     * @covers ::generatePlaceholder
+     */
+    public function testGeneratingPlaceholder(): void
+    {
+        $placeholder = Expression::generatePlaceholder(self::EXAMPLE_FQSEN);
+
+        self::assertSame(self::EXAMPLE_FQSEN_PLACEHOLDER, $placeholder);
+    }
+
+    /**
+     * @covers ::generatePlaceholder
+     */
+    public function testGeneratingPlaceholderErrorsUponPassingAnEmptyName(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        Expression::generatePlaceholder('');
+    }
+
+    /**
+     * @covers ::__construct
+     */
+    public function testExpressionTemplateCannotBeEmpty(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new Expression('', []);
+    }
+
+    /**
+     * @covers ::__construct
+     */
+    public function testPartsShouldContainFqsensOrTypes(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new Expression('This is an expression', [self::EXAMPLE_FQSEN_PLACEHOLDER => self::EXAMPLE_FQSEN]);
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getExpression
+     */
+    public function testGetExpressionTemplateString(): void
+    {
+        $expressionTemplate = sprintf('This is an %s expression', self::EXAMPLE_FQSEN_PLACEHOLDER);
+        $parts = [self::EXAMPLE_FQSEN_PLACEHOLDER => new Fqsen(self::EXAMPLE_FQSEN)];
+        $expression = new Expression($expressionTemplate, $parts);
+
+        $result = $expression->getExpression();
+
+        self::assertSame($expressionTemplate, $result);
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getParts
+     */
+    public function testGetExtractedParts(): void
+    {
+        $expressionTemplate = sprintf('This is an %s expression', self::EXAMPLE_FQSEN_PLACEHOLDER);
+        $parts = [self::EXAMPLE_FQSEN_PLACEHOLDER => new Fqsen(self::EXAMPLE_FQSEN)];
+        $expression = new Expression($expressionTemplate, $parts);
+
+        $result = $expression->getParts();
+
+        self::assertSame($parts, $result);
+    }
+
+    /**
+     * @covers ::__toString
+     */
+    public function testReplacePlaceholdersWhenCastingToString(): void
+    {
+        $expressionTemplate = sprintf('This is an %s expression', self::EXAMPLE_FQSEN_PLACEHOLDER);
+        $parts = [self::EXAMPLE_FQSEN_PLACEHOLDER => new Fqsen(self::EXAMPLE_FQSEN)];
+        $expression = new Expression($expressionTemplate, $parts);
+
+        $result = (string) $expression;
+
+        self::assertSame(sprintf('This is an %s expression', self::EXAMPLE_FQSEN), $result);
+    }
+
+    /**
+     * @covers ::render
+     */
+    public function testRenderingExpressionWithoutOverridesIsTheSameAsWhenCastingToString(): void
+    {
+        $expressionTemplate = sprintf('This is an %s expression', self::EXAMPLE_FQSEN_PLACEHOLDER);
+        $parts = [self::EXAMPLE_FQSEN_PLACEHOLDER => new Fqsen(self::EXAMPLE_FQSEN)];
+        $expression = new Expression($expressionTemplate, $parts);
+
+        $result = $expression->render();
+
+        self::assertSame((string) $expression, $result);
+    }
+
+    /**
+     * @covers ::render
+     */
+    public function testOverridePartsWhenRenderingExpression(): void
+    {
+        $replacement = 'ExpressionTest';
+
+        $expressionTemplate = sprintf('This is an %s expression', self::EXAMPLE_FQSEN_PLACEHOLDER);
+        $parts = [self::EXAMPLE_FQSEN_PLACEHOLDER => new Fqsen(self::EXAMPLE_FQSEN)];
+        $expression = new Expression($expressionTemplate, $parts);
+
+        $result = $expression->render([self::EXAMPLE_FQSEN_PLACEHOLDER => $replacement]);
+
+        self::assertSame(sprintf('This is an %s expression', $replacement), $result);
+    }
+}

--- a/tests/unit/phpDocumentor/Reflection/Php/ExpressionTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/ExpressionTest.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link http://phpdoc.org
+ */
+
 namespace phpDocumentor\Reflection\Php;
 
 use InvalidArgumentException;

--- a/tests/unit/phpDocumentor/Reflection/Php/ExpressionTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/ExpressionTest.php
@@ -15,21 +15,17 @@ namespace phpDocumentor\Reflection\Php;
 
 use InvalidArgumentException;
 use phpDocumentor\Reflection\Fqsen;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 use function sprintf;
 
-/**
- * @coversDefaultClass Expression
- * @covers ::__construct
- * @covers ::<private>
- */
+#[CoversClass(Expression::class)]
 final class ExpressionTest extends TestCase
 {
     private const EXAMPLE_FQSEN = '\\' . self::class;
     private const EXAMPLE_FQSEN_PLACEHOLDER = '{{ PHPDOC0450ed2a7bac1efcf0c13b6560767954 }}';
 
-    /** @covers ::generatePlaceholder */
     public function testGeneratingPlaceholder(): void
     {
         $placeholder = Expression::generatePlaceholder(self::EXAMPLE_FQSEN);
@@ -37,7 +33,6 @@ final class ExpressionTest extends TestCase
         self::assertSame(self::EXAMPLE_FQSEN_PLACEHOLDER, $placeholder);
     }
 
-    /** @covers ::generatePlaceholder */
     public function testGeneratingPlaceholderErrorsUponPassingAnEmptyName(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -45,7 +40,6 @@ final class ExpressionTest extends TestCase
         Expression::generatePlaceholder('');
     }
 
-    /** @covers ::__construct */
     public function testExpressionTemplateCannotBeEmpty(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -53,7 +47,6 @@ final class ExpressionTest extends TestCase
         new Expression('', []);
     }
 
-    /** @covers ::__construct */
     public function testPartsShouldContainFqsensOrTypes(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -61,10 +54,6 @@ final class ExpressionTest extends TestCase
         new Expression('This is an expression', [self::EXAMPLE_FQSEN_PLACEHOLDER => self::EXAMPLE_FQSEN]);
     }
 
-    /**
-     * @covers ::__construct
-     * @covers ::getExpression
-     */
     public function testGetExpressionTemplateString(): void
     {
         $expressionTemplate = sprintf('This is an %s expression', self::EXAMPLE_FQSEN_PLACEHOLDER);
@@ -76,10 +65,6 @@ final class ExpressionTest extends TestCase
         self::assertSame($expressionTemplate, $result);
     }
 
-    /**
-     * @covers ::__construct
-     * @covers ::getParts
-     */
     public function testGetExtractedParts(): void
     {
         $expressionTemplate = sprintf('This is an %s expression', self::EXAMPLE_FQSEN_PLACEHOLDER);
@@ -91,7 +76,6 @@ final class ExpressionTest extends TestCase
         self::assertSame($parts, $result);
     }
 
-    /** @covers ::__toString */
     public function testReplacePlaceholdersWhenCastingToString(): void
     {
         $expressionTemplate = sprintf('This is an %s expression', self::EXAMPLE_FQSEN_PLACEHOLDER);
@@ -103,7 +87,6 @@ final class ExpressionTest extends TestCase
         self::assertSame(sprintf('This is an %s expression', self::EXAMPLE_FQSEN), $result);
     }
 
-    /** @covers ::render */
     public function testRenderingExpressionWithoutOverridesIsTheSameAsWhenCastingToString(): void
     {
         $expressionTemplate = sprintf('This is an %s expression', self::EXAMPLE_FQSEN_PLACEHOLDER);
@@ -115,7 +98,6 @@ final class ExpressionTest extends TestCase
         self::assertSame((string) $expression, $result);
     }
 
-    /** @covers ::render */
     public function testOverridePartsWhenRenderingExpression(): void
     {
         $replacement = 'ExpressionTest';

--- a/tests/unit/phpDocumentor/Reflection/Php/ExpressionTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/ExpressionTest.php
@@ -29,9 +29,7 @@ final class ExpressionTest extends TestCase
     private const EXAMPLE_FQSEN = '\\' . self::class;
     private const EXAMPLE_FQSEN_PLACEHOLDER = '{{ PHPDOC0450ed2a7bac1efcf0c13b6560767954 }}';
 
-    /**
-     * @covers ::generatePlaceholder
-     */
+    /** @covers ::generatePlaceholder */
     public function testGeneratingPlaceholder(): void
     {
         $placeholder = Expression::generatePlaceholder(self::EXAMPLE_FQSEN);
@@ -39,9 +37,7 @@ final class ExpressionTest extends TestCase
         self::assertSame(self::EXAMPLE_FQSEN_PLACEHOLDER, $placeholder);
     }
 
-    /**
-     * @covers ::generatePlaceholder
-     */
+    /** @covers ::generatePlaceholder */
     public function testGeneratingPlaceholderErrorsUponPassingAnEmptyName(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -49,9 +45,7 @@ final class ExpressionTest extends TestCase
         Expression::generatePlaceholder('');
     }
 
-    /**
-     * @covers ::__construct
-     */
+    /** @covers ::__construct */
     public function testExpressionTemplateCannotBeEmpty(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -59,9 +53,7 @@ final class ExpressionTest extends TestCase
         new Expression('', []);
     }
 
-    /**
-     * @covers ::__construct
-     */
+    /** @covers ::__construct */
     public function testPartsShouldContainFqsensOrTypes(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -99,9 +91,7 @@ final class ExpressionTest extends TestCase
         self::assertSame($parts, $result);
     }
 
-    /**
-     * @covers ::__toString
-     */
+    /** @covers ::__toString */
     public function testReplacePlaceholdersWhenCastingToString(): void
     {
         $expressionTemplate = sprintf('This is an %s expression', self::EXAMPLE_FQSEN_PLACEHOLDER);
@@ -113,9 +103,7 @@ final class ExpressionTest extends TestCase
         self::assertSame(sprintf('This is an %s expression', self::EXAMPLE_FQSEN), $result);
     }
 
-    /**
-     * @covers ::render
-     */
+    /** @covers ::render */
     public function testRenderingExpressionWithoutOverridesIsTheSameAsWhenCastingToString(): void
     {
         $expressionTemplate = sprintf('This is an %s expression', self::EXAMPLE_FQSEN_PLACEHOLDER);
@@ -127,9 +115,7 @@ final class ExpressionTest extends TestCase
         self::assertSame((string) $expression, $result);
     }
 
-    /**
-     * @covers ::render
-     */
+    /** @covers ::render */
     public function testOverridePartsWhenRenderingExpression(): void
     {
         $replacement = 'ExpressionTest';

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/PropertyTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/PropertyTest.php
@@ -63,9 +63,9 @@ final class PropertyTest extends TestCase
     #[DataProvider('visibilityProvider')]
     public function testCreateWithVisibility(int $input, string $expectedVisibility): void
     {
-        $constantStub = $this->buildPropertyMock($input);
+        $propertyStub = $this->buildPropertyMock($input);
 
-        $class = $this->performCreate($constantStub);
+        $class = $this->performCreate($propertyStub);
 
         $property = current($class->getProperties());
         $this->assertProperty($property, $expectedVisibility);

--- a/tests/unit/phpDocumentor/Reflection/Php/PropertyTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/PropertyTest.php
@@ -56,23 +56,23 @@ final class PropertyTest extends TestCase
     {
         $property = new Property($this->fqsen);
 
-        $this->assertSame($this->fqsen, $property->getFqsen());
-        $this->assertEquals($this->fqsen->getName(), $property->getName());
+        self::assertSame($this->fqsen, $property->getFqsen());
+        self::assertEquals($this->fqsen->getName(), $property->getName());
     }
 
     public function testGettingWhetherPropertyIsStatic(): void
     {
         $property = new Property($this->fqsen, $this->visibility, $this->docBlock, null, false);
-        $this->assertFalse($property->isStatic());
+        self::assertFalse($property->isStatic());
 
         $property = new Property($this->fqsen, $this->visibility, $this->docBlock, null, true);
-        $this->assertTrue($property->isStatic());
+        self::assertTrue($property->isStatic());
     }
 
     public function testGettingWhetherPropertyIsReadOnly(): void
     {
         $property = new Property($this->fqsen, $this->visibility, $this->docBlock, null);
-        $this->assertFalse($property->isReadOnly());
+        self::assertFalse($property->isReadOnly());
 
         $property = new Property(
             $this->fqsen,
@@ -86,38 +86,40 @@ final class PropertyTest extends TestCase
             true,
         );
 
-        $this->assertTrue($property->isReadOnly());
+        self::assertTrue($property->isReadOnly());
     }
 
     public function testGettingVisibility(): void
     {
         $property = new Property($this->fqsen, $this->visibility, $this->docBlock, null, true);
 
-        $this->assertSame($this->visibility, $property->getVisibility());
+        self::assertSame($this->visibility, $property->getVisibility());
     }
 
     public function testSetAndGetTypes(): void
     {
         $property = new Property($this->fqsen, $this->visibility, $this->docBlock, null, true);
-        $this->assertEquals([], $property->getTypes());
+        self::assertEquals([], $property->getTypes());
 
         $property->addType('a');
-        $this->assertEquals(['a'], $property->getTypes());
+        self::assertEquals(['a'], $property->getTypes());
     }
 
     public function testGetDefault(): void
     {
         $property = new Property($this->fqsen, $this->visibility, $this->docBlock, null, false);
-        $this->assertNull($property->getDefault());
+        self::assertNull($property->getDefault());
 
-        $property = new Property($this->fqsen, $this->visibility, $this->docBlock, 'a', true);
-        $this->assertEquals('a', $property->getDefault());
+        $expression = new Expression('a');
+        $property = new Property($this->fqsen, $this->visibility, $this->docBlock, $expression, true);
+        self::assertSame('a', $property->getDefault());
+        self::assertSame($expression, $property->getDefault(false));
     }
 
     public function testGetDocBlock(): void
     {
         $property = new Property($this->fqsen, $this->visibility, $this->docBlock, null, false);
-        $this->assertSame($this->docBlock, $property->getDocBlock());
+        self::assertSame($this->docBlock, $property->getDocBlock());
     }
 
     public function testLineAndColumnNumberIsReturnedWhenALocationIsProvided(): void
@@ -140,9 +142,9 @@ final class PropertyTest extends TestCase
             $type,
         );
 
-        $this->assertSame($type, $fixture->getType());
+        self::assertSame($type, $fixture->getType());
 
         $fixture = new Property($this->fqsen);
-        $this->assertNull($fixture->getType());
+        self::assertNull($fixture->getType());
     }
 }


### PR DESCRIPTION
Values of constants, named arguments, etc, should be parsed to include types and FQSENs that can be used in phpDocumentor to display links with. Since these are now simple strings, I have refactored this into a template string system with placeholder values that a consumer could replace with its own values.

TODO:

- [x] Finish all tests
- [x] Verify all expressions are converted
- [x] Write more tests
- [x] Check if there are more types, other than Name, that should be converted. Like identifier?