### PR TITLE
Add reducers to factories to support attributes

### DIFF
--- a/src/phpDocumentor/Reflection/Php/Attribute.php
+++ b/src/phpDocumentor/Reflection/Php/Attribute.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Reflection\Php;
+
+use phpDocumentor\Reflection\Element;
+use phpDocumentor\Reflection\Fqsen;
+
+final class Attribute implements Element
+{
+    private Fqsen $fqsen;
+
+    /** @var CallArgument[] */
+    private array $arguments;
+
+    /** @param CallArgument[] $arguments */
+    public function __construct(Fqsen $fqsen, array $arguments)
+    {
+        $this->fqsen = $fqsen;
+        $this->arguments = $arguments;
+    }
+
+    public function getFqsen(): Fqsen
+    {
+        return $this->fqsen;
+    }
+
+    /** @return CallArgument[] */
+    public function getArguments(): array
+    {
+        return $this->arguments;
+    }
+
+    public function getName(): string
+    {
+        return $this->fqsen->getName();
+    }
+}

--- a/src/phpDocumentor/Reflection/Php/AttributeContainer.php
+++ b/src/phpDocumentor/Reflection/Php/AttributeContainer.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Reflection\Php;
+
+interface AttributeContainer
+{
+    public function addAttribute(Attribute $attribute): void;
+}

--- a/src/phpDocumentor/Reflection/Php/CallArgument.php
+++ b/src/phpDocumentor/Reflection/Php/CallArgument.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Reflection\Php;
+
+final class CallArgument
+{
+    private string $value;
+
+    private ?string $name;
+
+    public function __construct(
+        string $value,
+        ?string $name = null
+    ) {
+        $this->value = $value;
+        $this->name = $name;
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+}

--- a/src/phpDocumentor/Reflection/Php/Class_.php
+++ b/src/phpDocumentor/Reflection/Php/Class_.php
@@ -23,10 +23,11 @@ use phpDocumentor\Reflection\Metadata\MetaDataContainer as MetaDataContainerInte
  * Descriptor representing a Class.
  */
 // @codingStandardsIgnoreStart
-final class Class_ implements Element, MetaDataContainerInterface
+final class Class_ implements Element, MetaDataContainerInterface, AttributeContainer
 // @codingStandardsIgnoreEnd
 {
     use MetadataContainer;
+    use HasAttributes;
 
     /** @var Fqsen Full Qualified Structural Element Name */
     private Fqsen $fqsen;

--- a/src/phpDocumentor/Reflection/Php/Constant.php
+++ b/src/phpDocumentor/Reflection/Php/Constant.php
@@ -22,9 +22,10 @@ use phpDocumentor\Reflection\Metadata\MetaDataContainer as MetaDataContainerInte
 /**
  * Descriptor representing a constant
  */
-final class Constant implements Element, MetaDataContainerInterface
+final class Constant implements Element, MetaDataContainerInterface, AttributeContainer
 {
     use MetadataContainer;
+    use HasAttributes;
 
     private Fqsen $fqsen;
 

--- a/src/phpDocumentor/Reflection/Php/EnumCase.php
+++ b/src/phpDocumentor/Reflection/Php/EnumCase.php
@@ -10,9 +10,10 @@ use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Location;
 use phpDocumentor\Reflection\Metadata\MetaDataContainer as MetaDataContainerInterface;
 
-final class EnumCase implements Element, MetaDataContainerInterface
+final class EnumCase implements Element, MetaDataContainerInterface, AttributeContainer
 {
     use MetadataContainer;
+    use HasAttributes;
 
     private Fqsen $fqsen;
 

--- a/src/phpDocumentor/Reflection/Php/Enum_.php
+++ b/src/phpDocumentor/Reflection/Php/Enum_.php
@@ -20,9 +20,10 @@ use phpDocumentor\Reflection\Location;
 use phpDocumentor\Reflection\Metadata\MetaDataContainer as MetaDataContainerInterface;
 use phpDocumentor\Reflection\Type;
 
-final class Enum_ implements Element, MetaDataContainerInterface
+final class Enum_ implements Element, MetaDataContainerInterface, AttributeContainer
 {
     use MetadataContainer;
+    use HasAttributes;
 
     /** @var Fqsen Full Qualified Structural Element Name */
     private Fqsen $fqsen;

--- a/src/phpDocumentor/Reflection/Php/Factory/Argument.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Argument.php
@@ -29,7 +29,7 @@ use Webmozart\Assert\Assert;
  * @see ArgumentDescriptor
  * @see \PhpParser\Node\Arg
  */
-final class Argument extends AbstractFactory implements ProjectFactoryStrategy
+final class Argument implements ProjectFactoryStrategy
 {
     private PrettyPrinter $valueConverter;
 
@@ -56,7 +56,7 @@ final class Argument extends AbstractFactory implements ProjectFactoryStrategy
      * @param Param $object object to convert to an Element
      * @param StrategyContainer $strategies used to convert nested objects.
      */
-    protected function doCreate(
+    public function create(
         ContextStack $context,
         object $object,
         StrategyContainer $strategies

--- a/src/phpDocumentor/Reflection/Php/Factory/ClassConstant.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/ClassConstant.php
@@ -61,7 +61,7 @@ final class ClassConstant extends AbstractFactory
         ContextStack $context,
         object $object,
         StrategyContainer $strategies
-    ): void {
+    ): ?object {
         $constantContainer = $context->peek();
         Assert::isInstanceOfAny(
             $constantContainer,
@@ -86,6 +86,8 @@ final class ClassConstant extends AbstractFactory
                 $const->isFinal()
             ));
         }
+
+        return null;
     }
 
     /**

--- a/src/phpDocumentor/Reflection/Php/Factory/Class_.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Class_.php
@@ -17,7 +17,6 @@ use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Location;
 use phpDocumentor\Reflection\Php\Class_ as ClassElement;
 use phpDocumentor\Reflection\Php\File as FileElement;
-use phpDocumentor\Reflection\Php\ProjectFactoryStrategy;
 use phpDocumentor\Reflection\Php\StrategyContainer;
 use PhpParser\Node\Stmt\Class_ as ClassNode;
 
@@ -26,7 +25,7 @@ use function assert;
 /**
  * Strategy to create a ClassElement including all sub elements.
  */
-final class Class_ extends AbstractFactory implements ProjectFactoryStrategy
+final class Class_ extends AbstractFactory
 {
     public function matches(ContextStack $context, object $object): bool
     {
@@ -42,7 +41,7 @@ final class Class_ extends AbstractFactory implements ProjectFactoryStrategy
      * @param ContextStack $context of the created object
      * @param ClassNode $object
      */
-    protected function doCreate(ContextStack $context, object $object, StrategyContainer $strategies): void
+    protected function doCreate(ContextStack $context, object $object, StrategyContainer $strategies): ?object
     {
         $docBlock = $this->createDocBlock($object->getDocComment(), $context->getTypeContext());
 
@@ -72,5 +71,7 @@ final class Class_ extends AbstractFactory implements ProjectFactoryStrategy
             $strategy = $strategies->findMatching($thisContext, $stmt);
             $strategy->create($thisContext, $stmt, $strategies);
         }
+
+        return $classElement;
     }
 }

--- a/src/phpDocumentor/Reflection/Php/Factory/ConstructorPromotion.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/ConstructorPromotion.php
@@ -49,7 +49,7 @@ final class ConstructorPromotion extends AbstractFactory
     /**
      * @param ClassMethod $object
      */
-    protected function doCreate(ContextStack $context, object $object, StrategyContainer $strategies): void
+    protected function doCreate(ContextStack $context, object $object, StrategyContainer $strategies): ?object
     {
         $this->methodStrategy->create($context, $object, $strategies);
 
@@ -60,6 +60,8 @@ final class ConstructorPromotion extends AbstractFactory
 
             $this->promoteParameterToProperty($context, $param);
         }
+
+        return $context->peek();
     }
 
     private function promoteParameterToProperty(ContextStack $context, Param $param): void

--- a/src/phpDocumentor/Reflection/Php/Factory/Define.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Define.php
@@ -88,7 +88,7 @@ final class Define extends AbstractFactory
         ContextStack $context,
         object $object,
         StrategyContainer $strategies
-    ): void {
+    ): ?object {
         $expression = $object->expr;
         assert($expression instanceof FuncCall);
 
@@ -96,7 +96,7 @@ final class Define extends AbstractFactory
 
         //We cannot calculate the name of a variadic consuming define.
         if ($name instanceof VariadicPlaceholder || $value instanceof VariadicPlaceholder) {
-            return;
+            return null;
         }
 
         $file = $context->search(FileElement::class);
@@ -104,7 +104,7 @@ final class Define extends AbstractFactory
 
         $fqsen = $this->determineFqsen($name, $context);
         if ($fqsen === null) {
-            return;
+            return null;
         }
 
         $constant = new ConstantElement(
@@ -116,6 +116,8 @@ final class Define extends AbstractFactory
         );
 
         $file->addConstant($constant);
+
+        return $constant;
     }
 
     private function determineValue(?Arg $value): ?string

--- a/src/phpDocumentor/Reflection/Php/Factory/EnumCase.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/EnumCase.php
@@ -32,17 +32,22 @@ final class EnumCase extends AbstractFactory
     /**
      * @param EnumCaseNode $object
      */
-    protected function doCreate(ContextStack $context, object $object, StrategyContainer $strategies): void
+    protected function doCreate(ContextStack $context, object $object, StrategyContainer $strategies): ?object
     {
         $docBlock = $this->createDocBlock($object->getDocComment(), $context->getTypeContext());
         $enum = $context->peek();
         assert($enum instanceof EnumElement);
-        $enum->addCase(new EnumCaseElement(
+
+        $case = new EnumCaseElement(
             $object->getAttribute('fqsen'),
             $docBlock,
             new Location($object->getLine()),
             new Location($object->getEndLine()),
             $object->expr !== null ? $this->prettyPrinter->prettyPrintExpr($object->expr) : null
-        ));
+        );
+
+        $enum->addCase($case);
+
+        return $case;
     }
 }

--- a/src/phpDocumentor/Reflection/Php/Factory/Enum_.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Enum_.php
@@ -29,7 +29,7 @@ final class Enum_ extends AbstractFactory
     }
 
     /** @param EnumNode $object */
-    protected function doCreate(ContextStack $context, object $object, StrategyContainer $strategies): void
+    protected function doCreate(ContextStack $context, object $object, StrategyContainer $strategies): ?object
     {
         $docBlock = $this->createDocBlock($object->getDocComment(), $context->getTypeContext());
 
@@ -56,5 +56,7 @@ final class Enum_ extends AbstractFactory
             $strategy = $strategies->findMatching($thisContext, $stmt);
             $strategy->create($thisContext, $stmt, $strategies);
         }
+
+        return $enum;
     }
 }

--- a/src/phpDocumentor/Reflection/Php/Factory/File.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/File.php
@@ -86,17 +86,19 @@ final class File extends AbstractFactory
      * @param FileSystemFile $object path to the file to convert to an File object.
      * @param StrategyContainer $strategies used to convert nested objects.
      */
-    protected function doCreate(ContextStack $context, object $object, StrategyContainer $strategies): void
+    protected function doCreate(ContextStack $context, object $object, StrategyContainer $strategies): ?object
     {
         $command = new CreateCommand($context, $object, $strategies);
         $middlewareChain = $this->middlewareChain;
 
         $file = $middlewareChain($command);
         if ($file === null) {
-            return;
+            return null;
         }
 
         $context->getProject()->addFile($file);
+
+        return $file;
     }
 
     private function createFile(CreateCommand $command): FileElement

--- a/src/phpDocumentor/Reflection/Php/Factory/Function_.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Function_.php
@@ -46,7 +46,7 @@ final class Function_ extends AbstractFactory implements ProjectFactoryStrategy
         ContextStack $context,
         object $object,
         StrategyContainer $strategies
-    ): void {
+    ): ?object {
         $file = $context->peek();
         Assert::isInstanceOf($file, FileElement::class);
 
@@ -68,12 +68,14 @@ final class Function_ extends AbstractFactory implements ProjectFactoryStrategy
         }
 
         if (!is_array($object->stmts)) {
-            return;
+            return null;
         }
 
         foreach ($object->stmts as $stmt) {
             $strategy = $strategies->findMatching($thisContext, $stmt);
             $strategy->create($thisContext, $stmt, $strategies);
         }
+
+        return $function;
     }
 }

--- a/src/phpDocumentor/Reflection/Php/Factory/GlobalConstant.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/GlobalConstant.php
@@ -60,7 +60,7 @@ final class GlobalConstant extends AbstractFactory
         ContextStack $context,
         object $object,
         StrategyContainer $strategies
-    ): void {
+    ): ?object {
         $constants = new GlobalConstantIterator($object);
         $file = $context->peek();
         Assert::isInstanceOf($file, FileElement::class);
@@ -76,5 +76,7 @@ final class GlobalConstant extends AbstractFactory
                 )
             );
         }
+
+        return null;
     }
 }

--- a/src/phpDocumentor/Reflection/Php/Factory/Interface_.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Interface_.php
@@ -46,7 +46,7 @@ final class Interface_ extends AbstractFactory implements ProjectFactoryStrategy
         ContextStack $context,
         object $object,
         StrategyContainer $strategies
-    ): void {
+    ): ?object {
         $docBlock = $this->createDocBlock($object->getDocComment(), $context->getTypeContext());
         $parents  = [];
         foreach ($object->extends as $extend) {
@@ -69,5 +69,7 @@ final class Interface_ extends AbstractFactory implements ProjectFactoryStrategy
             $strategy = $strategies->findMatching($thisContext, $stmt);
             $strategy->create($thisContext, $stmt, $strategies);
         }
+
+        return $interface;
     }
 }

--- a/src/phpDocumentor/Reflection/Php/Factory/Method.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Method.php
@@ -18,7 +18,6 @@ use phpDocumentor\Reflection\Php\Class_;
 use phpDocumentor\Reflection\Php\Enum_;
 use phpDocumentor\Reflection\Php\Interface_;
 use phpDocumentor\Reflection\Php\Method as MethodDescriptor;
-use phpDocumentor\Reflection\Php\ProjectFactoryStrategy;
 use phpDocumentor\Reflection\Php\StrategyContainer;
 use phpDocumentor\Reflection\Php\Trait_;
 use phpDocumentor\Reflection\Php\Visibility;
@@ -30,7 +29,7 @@ use function is_array;
 /**
  * Strategy to create MethodDescriptor and arguments when applicable.
  */
-final class Method extends AbstractFactory implements ProjectFactoryStrategy
+final class Method extends AbstractFactory
 {
     public function matches(ContextStack $context, object $object): bool
     {
@@ -47,7 +46,7 @@ final class Method extends AbstractFactory implements ProjectFactoryStrategy
         ContextStack $context,
         object $object,
         StrategyContainer $strategies
-    ): void {
+    ): ?object {
         $methodContainer = $context->peek();
         Assert::isInstanceOfAny(
             $methodContainer,
@@ -80,13 +79,15 @@ final class Method extends AbstractFactory implements ProjectFactoryStrategy
         }
 
         if (!is_array($object->stmts)) {
-            return;
+            return null;
         }
 
         foreach ($object->stmts as $stmt) {
             $strategy = $strategies->findMatching($thisContext, $stmt);
             $strategy->create($thisContext, $stmt, $strategies);
         }
+
+        return $method;
     }
 
     /**

--- a/src/phpDocumentor/Reflection/Php/Factory/Property.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Property.php
@@ -62,7 +62,7 @@ final class Property extends AbstractFactory implements ProjectFactoryStrategy
         ContextStack $context,
         object $object,
         StrategyContainer $strategies
-    ): void {
+    ): ?object {
         $propertyContainer = $context->peek();
         Assert::isInstanceOfAny(
             $propertyContainer,
@@ -93,6 +93,8 @@ final class Property extends AbstractFactory implements ProjectFactoryStrategy
                 )
             );
         }
+
+        return null;
     }
 
     /**

--- a/src/phpDocumentor/Reflection/Php/Factory/Reducer/Attribute.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Reducer/Attribute.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Reflection\Php\Factory\Reducer;
+
+use InvalidArgumentException;
+use phpDocumentor\Reflection\Fqsen;
+use phpDocumentor\Reflection\Php\AttributeContainer;
+use phpDocumentor\Reflection\Php\CallArgument;
+use phpDocumentor\Reflection\Php\Factory\ContextStack;
+use phpDocumentor\Reflection\Php\StrategyContainer;
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\PrettyPrinter\Standard;
+
+use function array_map;
+use function assert;
+use function get_class;
+use function property_exists;
+use function sprintf;
+
+final class Attribute implements Reducer
+{
+    private Standard $printer;
+
+    public function __construct()
+    {
+        $this->printer = new Standard();
+    }
+
+    public function reduce(
+        ContextStack $context,
+        object $object,
+        StrategyContainer $strategies,
+        ?object $carry
+    ): ?object {
+        if ($carry === null) {
+            return null;
+        }
+
+        if (property_exists($object, 'attrGroups') === false || isset($object->attrGroups) === false) {
+            return $carry;
+        }
+
+        if ($carry instanceof AttributeContainer === false) {
+            throw new InvalidArgumentException(sprintf('Attribute can not be added on %s', get_class($carry)));
+        }
+
+        foreach ($object->attrGroups as $attrGroup) {
+            assert($attrGroup instanceof Node\AttributeGroup);
+            foreach ($attrGroup->attrs as $attr) {
+                $carry->addAttribute(
+                    new \phpDocumentor\Reflection\Php\Attribute(
+                        new Fqsen('\\' . $attr->name->toString()),
+                        array_map([$this, 'buildCallArgument'], $attr->args),
+                    )
+                );
+            }
+        }
+
+        return $carry;
+    }
+
+    private function buildCallArgument(Arg $arg): CallArgument
+    {
+        return new CallArgument(
+            $this->printer->prettyPrintExpr($arg->value),
+            $arg->name !== null ? $arg->name->toString() : null,
+        );
+    }
+}

--- a/src/phpDocumentor/Reflection/Php/Factory/Reducer/Reducer.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Reducer/Reducer.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Reflection\Php\Factory\Reducer;
+
+use phpDocumentor\Reflection\Php\Factory\ContextStack;
+use phpDocumentor\Reflection\Php\StrategyContainer;
+
+interface Reducer
+{
+    public function reduce(
+        ContextStack $context,
+        object $object,
+        StrategyContainer $strategies,
+        ?object $carry
+    ): ?object;
+}

--- a/src/phpDocumentor/Reflection/Php/Factory/Trait_.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Trait_.php
@@ -15,13 +15,12 @@ namespace phpDocumentor\Reflection\Php\Factory;
 
 use phpDocumentor\Reflection\Location;
 use phpDocumentor\Reflection\Php\File as FileElement;
-use phpDocumentor\Reflection\Php\ProjectFactoryStrategy;
 use phpDocumentor\Reflection\Php\StrategyContainer;
 use phpDocumentor\Reflection\Php\Trait_ as TraitElement;
 use PhpParser\Node\Stmt\Trait_ as TraitNode;
 use Webmozart\Assert\Assert;
 
-final class Trait_ extends AbstractFactory implements ProjectFactoryStrategy
+final class Trait_ extends AbstractFactory
 {
     public function matches(ContextStack $context, object $object): bool
     {
@@ -37,7 +36,7 @@ final class Trait_ extends AbstractFactory implements ProjectFactoryStrategy
      * @param ContextStack $context used to convert nested objects.
      * @param TraitNode $object
      */
-    protected function doCreate(ContextStack $context, object $object, StrategyContainer $strategies): void
+    protected function doCreate(ContextStack $context, object $object, StrategyContainer $strategies): ?object
     {
         $trait = new TraitElement(
             $object->getAttribute('fqsen'),
@@ -55,5 +54,7 @@ final class Trait_ extends AbstractFactory implements ProjectFactoryStrategy
             $strategy = $strategies->findMatching($thisContext, $stmt);
             $strategy->create($thisContext, $stmt, $strategies);
         }
+
+        return $trait;
     }
 }

--- a/src/phpDocumentor/Reflection/Php/Function_.php
+++ b/src/phpDocumentor/Reflection/Php/Function_.php
@@ -25,10 +25,11 @@ use phpDocumentor\Reflection\Types\Mixed_;
  * Descriptor representing a function
  */
 // @codingStandardsIgnoreStart
-final class Function_ implements Element, MetaDataContainerInterface
+final class Function_ implements Element, MetaDataContainerInterface, AttributeContainer
 // // @codingStandardsIgnoreEnd
 {
     use MetadataContainer;
+    use HasAttributes;
 
     /** @var Fqsen Full Qualified Structural Element Name */
     private Fqsen $fqsen;

--- a/src/phpDocumentor/Reflection/Php/HasAttributes.php
+++ b/src/phpDocumentor/Reflection/Php/HasAttributes.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Reflection\Php;
+
+trait HasAttributes
+{
+    /** @var Attribute[] */
+    private array $attributes = [];
+
+    public function addAttribute(Attribute $attribute): void
+    {
+        $this->attributes[] = $attribute;
+    }
+
+    /**
+     * @return Attribute[]
+     */
+    public function getAttributes(): array
+    {
+        return $this->attributes;
+    }
+}

--- a/src/phpDocumentor/Reflection/Php/Interface_.php
+++ b/src/phpDocumentor/Reflection/Php/Interface_.php
@@ -23,9 +23,10 @@ use Webmozart\Assert\Assert;
 /**
  * Descriptor representing an Interface.
  */
-final class Interface_ implements Element, MetaDataContainerInterface
+final class Interface_ implements Element, MetaDataContainerInterface, AttributeContainer
 {
     use MetadataContainer;
+    use HasAttributes;
 
     /** @var Fqsen Full Qualified Structural Element Name */
     private Fqsen $fqsen;

--- a/src/phpDocumentor/Reflection/Php/Method.php
+++ b/src/phpDocumentor/Reflection/Php/Method.php
@@ -24,9 +24,10 @@ use phpDocumentor\Reflection\Types\Mixed_;
 /**
  * Descriptor representing a Method in a Class, Interface or Trait.
  */
-final class Method implements Element, MetaDataContainerInterface
+final class Method implements Element, MetaDataContainerInterface, AttributeContainer
 {
     use MetadataContainer;
+    use HasAttributes;
 
     /** @var DocBlock|null documentation of this method. */
     private ?DocBlock $docBlock = null;
@@ -168,8 +169,6 @@ final class Method implements Element, MetaDataContainerInterface
 
     /**
      * Returns the DocBlock of this method if available.
-     *
-     * @returns null|DocBlock
      */
     public function getDocBlock(): ?DocBlock
     {

--- a/src/phpDocumentor/Reflection/Php/ProjectFactory.php
+++ b/src/phpDocumentor/Reflection/Php/ProjectFactory.php
@@ -32,6 +32,7 @@ use phpDocumentor\Reflection\Php\Factory\Interface_;
 use phpDocumentor\Reflection\Php\Factory\Method;
 use phpDocumentor\Reflection\Php\Factory\Noop;
 use phpDocumentor\Reflection\Php\Factory\Property;
+use phpDocumentor\Reflection\Php\Factory\Reducer\Attribute;
 use phpDocumentor\Reflection\Php\Factory\Trait_;
 use phpDocumentor\Reflection\Php\Factory\TraitUse;
 use phpDocumentor\Reflection\Project as ProjectInterface;
@@ -72,7 +73,7 @@ final class ProjectFactory implements ProjectFactoryInterface
             [
                 new \phpDocumentor\Reflection\Php\Factory\Namespace_(),
                 new Argument(new PrettyPrinter()),
-                new Class_($docblockFactory),
+                new Class_($docblockFactory, [new Attribute()]),
                 new Enum_($docblockFactory),
                 new EnumCase($docblockFactory, new PrettyPrinter()),
                 new Define($docblockFactory, new PrettyPrinter()),
@@ -84,6 +85,7 @@ final class ProjectFactory implements ProjectFactoryInterface
                 $methodStrategy,
                 new Property($docblockFactory, new PrettyPrinter()),
                 new Trait_($docblockFactory),
+
                 new IfStatement(),
                 new TraitUse(),
             ]

--- a/src/phpDocumentor/Reflection/Php/Property.php
+++ b/src/phpDocumentor/Reflection/Php/Property.php
@@ -23,9 +23,10 @@ use phpDocumentor\Reflection\Type;
 /**
  * Descriptor representing a property.
  */
-final class Property implements Element, MetaDataContainerInterface
+final class Property implements Element, MetaDataContainerInterface, AttributeContainer
 {
     use MetadataContainer;
+    use HasAttributes;
 
     private Fqsen $fqsen;
 

--- a/src/phpDocumentor/Reflection/Php/Trait_.php
+++ b/src/phpDocumentor/Reflection/Php/Trait_.php
@@ -22,9 +22,10 @@ use phpDocumentor\Reflection\Metadata\MetaDataContainer as MetaDataContainerInte
 /**
  * Descriptor representing a Trait.
  */
-final class Trait_ implements Element, MetaDataContainerInterface
+final class Trait_ implements Element, MetaDataContainerInterface, AttributeContainer
 {
     use MetadataContainer;
+    use HasAttributes;
 
     /** @var Fqsen Full Qualified Structural Element Name */
     private Fqsen $fqsen;

--- a/tests/integration/data/Luigi/Pizza.php
+++ b/tests/integration/data/Luigi/Pizza.php
@@ -11,6 +11,8 @@
 
 namespace Luigi;
 
+#[\Food("Pizza")]
+#[\Food(country: "Italy", originDate: Pizza::class)]
 class Pizza extends \Pizza
 {
     const


### PR DESCRIPTION
To make it easier to add reused paths reducers are introduced. These will allow us to move steps in the production of elements to a separate class that will make it easier to reuse the logic between factories.