### PR TITLE
Allow PHP 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     },
     "require": {
-        "php": "8.1.*|8.2.*|8.3.*",
+        "php": "^8.1",
         "nikic/php-parser": "~4.18 || ^5.0",
         "phpdocumentor/reflection-common": "^2.1",
         "phpdocumentor/reflection-docblock": "^5",


### PR DESCRIPTION
I'm keep getting this message on PHP 8.4 testing:

```bash
Installing dependencies from lock file (including require-dev)
Verifying lock file contents can be installed on current platform.
Your lock file does not contain a compatible set of packages. Please run composer update.
  Problem 1
    - phpdocumentor/reflection is locked to version 6.0.0 and an update of this package was not requested.
    - phpdocumentor/reflection 6.0.0 requires php 8.1.*|8.2.*|8.3.* -> your php version (8.4.1) does not satisfy that requirement.
  Problem 2
    - spatie/laravel-data is locked to version 4.11.1 and an update of this package was not requested.
    - phpdocumentor/reflection 6.0.0 requires php 8.1.*|8.2.*|8.3.* -> your php version (8.4.1) does not satisfy that requirement.
    - spatie/laravel-data 4.11.1 requires phpdocumentor/reflection ^6.0 -> satisfiable by phpdocumentor/reflection[6.0.0].
```
Is there any reason why PHP versions are fixed defined? :)