### PR TITLE
Update ConstructorPromotion.php

### DIFF
--- a/tests/integration/data/PHP8/ConstructorPromotion.php
+++ b/tests/integration/data/PHP8/ConstructorPromotion.php
@@ -22,7 +22,7 @@ class ConstructorPromotion
          * @var string $name property description
          */
         public string $name,
-        protected string $email = 'test@example.com',
         private DateTimeImmutable $birth_date,
+        protected string $email = 'test@example.com',
     ) {}
 }


### PR DESCRIPTION
the optional parameter $email is declared before a required parameter $birth_date, which is not allowed in PHP 8. In PHP, optional parameters must always come after the required parameters.