### PR TITLE
Add support for PHP 8.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     },
     "require": {
-        "php": "8.1.*|8.2.*|8.3.*|8.4.*",
+        "php": "8.1.*|8.2.*|8.3.*|8.4.*|8.5.*",
         "composer-runtime-api": "^2",
         "nikic/php-parser": "~4.18 || ^5.0",
         "phpdocumentor/reflection-common": "^2.1",


### PR DESCRIPTION
A new version of PHP has been released: https://www.php.net/releases/8.5/en.php
The tests are passing. It seems that there are only internal deprecation errors.
I suggest adding the ability to install this package for PHP 8.5

<img width="764" height="242" alt="image" src="https://github.com/user-attachments/assets/2a466fd7-6f99-4fa4-b791-512d495958ff" />
