### PR TITLE
Fix syntax error in test PropertyHook

### DIFF
--- a/tests/integration/data/PHP84/PropertyHook.php
+++ b/tests/integration/data/PHP84/PropertyHook.php
@@ -8,7 +8,7 @@ class PropertyHook
 
     /** @var string this is my property */
     #[Property(new DateTimeImmutable())]
-    public string $example = 'default value' {
+    public string $example {
         /** Not sure this works, but it gets */
         #[Getter(new DateTimeImmutable())]
         get {

--- a/tests/integration/data/PHP84/PropertyHookAsymmetric.php
+++ b/tests/integration/data/PHP84/PropertyHookAsymmetric.php
@@ -8,7 +8,7 @@ class PropertyHook
 
     /** @var string this is my property */
     #[Property(new DateTimeImmutable())]
-    public private(set) string $example = 'default value' {
+    public private(set) string $example {
         get {
             if ($this->modified) {
                 return $this->foo . ' (modified)';


### PR DESCRIPTION
php -l

- `Cannot specify default value for virtual hooked property`