### PR TITLE
Add support for `phpdocumentor/reflection-docblock` v6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
         "php": "^7.4|8.0.*|8.1.*|8.2.*|8.3.*",
         "nikic/php-parser": "~4.14",
         "phpdocumentor/reflection-common": "^2.1",
-        "phpdocumentor/reflection-docblock": "^5",
-        "phpdocumentor/type-resolver": "^1.2",
+        "phpdocumentor/reflection-docblock": "^5.0 || ^6.0",
+        "phpdocumentor/type-resolver": "^1.2 || ^2.0",
         "symfony/polyfill-php80": "^1.28",
         "webmozart/assert": "^1.7"
     },


### PR DESCRIPTION
We really need support for `phpdocumentor/reflection-docblock` v6 in this version, as we need support for PHP 7.4. Is it possible to do this?

https://github.com/yiisoft/yii2-apidoc/blob/caeb69a9119b7e8fa38b913f04d034ad437eeba7/composer.json#L24-L27

It would also be great to support the sixth version of `phpdocumentor/reflection-docblock` in the sixth version of this package.