### PR TITLE
Remove redundant symfony/polyfill-php80 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
         "phpdocumentor/reflection-common": "^2.1",
         "phpdocumentor/reflection-docblock": "^6.0",
         "phpdocumentor/type-resolver": "^2.0",
-        "symfony/polyfill-php80": "^1.28",
         "webmozart/assert": "^1.7 || ^2.1"
     },
     "require-dev": {


### PR DESCRIPTION
This package depends on `symfony/polyfill-php80`, but also `php: 8.1.*|8.2.*|8.3.*|8.4.*|8.5.*`, so the polyfill requirement doesn't seem necessary anymore?