### PR TITLE
Add support for PHP 8.4 interface properties

### DIFF
--- a/src/phpDocumentor/Reflection/Php/Factory/Property.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/Property.php
@@ -18,6 +18,7 @@ use phpDocumentor\Reflection\DocBlockFactoryInterface;
 use phpDocumentor\Reflection\Location;
 use phpDocumentor\Reflection\Php\Class_;
 use phpDocumentor\Reflection\Php\Factory\Reducer\Reducer;
+use phpDocumentor\Reflection\Php\Interface_;
 use phpDocumentor\Reflection\Php\Property as PropertyDescriptor;
 use phpDocumentor\Reflection\Php\StrategyContainer;
 use phpDocumentor\Reflection\Php\Trait_;
@@ -69,6 +70,7 @@ final class Property extends AbstractFactory
             [
                 Class_::class,
                 Trait_::class,
+                Interface_::class,
             ],
         );
 

--- a/src/phpDocumentor/Reflection/Php/Interface_.php
+++ b/src/phpDocumentor/Reflection/Php/Interface_.php
@@ -37,6 +37,9 @@ final class Interface_ implements Element, MetaDataContainerInterface, Attribute
     /** @var Method[] */
     private array $methods = [];
 
+    /** @var Property[] */
+    private array $properties = [];
+
     private readonly Location $location;
 
     private readonly Location $endLocation;
@@ -93,6 +96,24 @@ final class Interface_ implements Element, MetaDataContainerInterface, Attribute
     public function addMethod(Method $method): void
     {
         $this->methods[(string) $method->getFqsen()] = $method;
+    }
+
+    /**
+     * Returns the properties of this interface.
+     *
+     * @return Property[]
+     */
+    public function getProperties(): array
+    {
+        return $this->properties;
+    }
+
+    /**
+     * Add a property to this interface.
+     */
+    public function addProperty(Property $property): void
+    {
+        $this->properties[(string) $property->getFqsen()] = $property;
     }
 
     /**

--- a/tests/integration/InterfacePropertyTest.php
+++ b/tests/integration/InterfacePropertyTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace integration;
 
+use EliasHaeussler\PHPUnitAttributes\Attribute\RequiresPackage;
 use phpDocumentor\Reflection\File\LocalFile;
 use phpDocumentor\Reflection\Php\ProjectFactory;
 use phpDocumentor\Reflection\Php\Visibility;
@@ -12,6 +13,7 @@ use phpDocumentor\Reflection\Types\String_;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
 
+#[RequiresPackage('nikic/php-parser', '>= 5.2')]
 #[CoversNothing]
 final class InterfacePropertyTest extends TestCase
 {

--- a/tests/integration/InterfacePropertyTest.php
+++ b/tests/integration/InterfacePropertyTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace integration;
+
+use phpDocumentor\Reflection\File\LocalFile;
+use phpDocumentor\Reflection\Php\ProjectFactory;
+use phpDocumentor\Reflection\Php\Visibility;
+use phpDocumentor\Reflection\Types\Integer;
+use phpDocumentor\Reflection\Types\String_;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+final class InterfacePropertyTest extends TestCase
+{
+    public function testInterfacePropertiesAreParsed(): void
+    {
+        $file = __DIR__ . '/data/PHP84/InterfaceProperties.php';
+        $projectFactory = ProjectFactory::createInstance();
+        $project = $projectFactory->create('My project', [new LocalFile($file)]);
+
+        $interfaces = $project->getFiles()[$file]->getInterfaces();
+
+        $hasId = $interfaces['\PHP84\HasId'];
+        $properties = $hasId->getProperties();
+        $this->assertCount(1, $properties);
+        $idProperty = $properties['\PHP84\HasId::$id'];
+        $this->assertEquals(new Integer(), $idProperty->getType());
+        $this->assertEquals(new Visibility(Visibility::PUBLIC_), $idProperty->getVisibility());
+        $this->assertCount(1, $idProperty->getHooks());
+        $this->assertEquals('get', $idProperty->getHooks()[0]->getName());
+
+        $hasName = $interfaces['\PHP84\HasName'];
+        $properties = $hasName->getProperties();
+        $this->assertCount(1, $properties);
+        $nameProperty = $properties['\PHP84\HasName::$name'];
+        $this->assertEquals(new String_(), $nameProperty->getType());
+        $this->assertCount(2, $nameProperty->getHooks());
+    }
+}

--- a/tests/integration/data/PHP84/InterfaceProperties.php
+++ b/tests/integration/data/PHP84/InterfaceProperties.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHP84;
+
+interface HasId
+{
+    public int $id { get; }
+}
+
+interface HasName
+{
+    public string $name { get; set; }
+}

--- a/tests/unit/phpDocumentor/Reflection/Php/Interface_Test.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Interface_Test.php
@@ -18,7 +18,6 @@ use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Location;
 use phpDocumentor\Reflection\Metadata\MetaDataContainer as MetaDataContainerInterface;
-use phpDocumentor\Reflection\Php\Property;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 

--- a/tests/unit/phpDocumentor/Reflection/Php/Interface_Test.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Interface_Test.php
@@ -18,6 +18,7 @@ use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Location;
 use phpDocumentor\Reflection\Metadata\MetaDataContainer as MetaDataContainerInterface;
+use phpDocumentor\Reflection\Php\Property;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 
@@ -28,6 +29,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass('\phpDocumentor\Reflection\Php\Method')]
 #[UsesClass('\phpDocumentor\Reflection\Php\Constant')]
 #[UsesClass('\phpDocumentor\Reflection\Php\Visibility')]
+#[UsesClass('\phpDocumentor\Reflection\Php\Property')]
 final class Interface_Test extends TestCase
 {
     use MetadataContainerTestHelper;
@@ -94,6 +96,17 @@ final class Interface_Test extends TestCase
         $this->fixture->addMethod($method);
 
         $this->assertEquals(['\MySpace\MyInterface::myMethod()' => $method], $this->fixture->getMethods());
+    }
+
+    public function testSettingAndGettingProperties(): void
+    {
+        $this->assertEquals([], $this->fixture->getProperties());
+
+        $property = new Property(new Fqsen('\MySpace\MyInterface::$myProperty'));
+
+        $this->fixture->addProperty($property);
+
+        $this->assertEquals(['\MySpace\MyInterface::$myProperty' => $property], $this->fixture->getProperties());
     }
 
     public function testReturningTheParentsOfThisInterface(): void


### PR DESCRIPTION
## Summary

PHP 8.4 allows declaring properties in interfaces using property hooks:

```php
interface HasId
{
    public int $id { get; }
}
```

This was not supported by the reflection library, causing a crash when phpDocumentor encountered interface properties (`Expected an instance of any of Class_, Trait_. Got: Interface_`).

- Add `$properties` array, `getProperties()`, and `addProperty()` to `Interface_`, following the same pattern as `Trait_`
- Add `Interface_::class` to the assertion in `Factory\Property::doCreate()`
- Add unit test for `Interface_` property accessors
- Add integration test parsing a PHP 8.4 interface with hooked properties

Fixes phpDocumentor/phpDocumentor#4061