### PR TITLE
Include file path and line number in parse error messages

### DIFF
--- a/src/phpDocumentor/Reflection/Php/Factory/File.php
+++ b/src/phpDocumentor/Reflection/Php/Factory/File.php
@@ -105,7 +105,7 @@ final class File extends AbstractFactory
     {
         $file = $command->getFile();
         $code = $file->getContents();
-        $nodes = $this->nodesFactory->create($code);
+        $nodes = $this->nodesFactory->create($code, $file->path());
 
         $fileToContext = new FileToContext();
         $typeContext = $fileToContext($nodes);

--- a/src/phpDocumentor/Reflection/Php/NodesFactory.php
+++ b/src/phpDocumentor/Reflection/Php/NodesFactory.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Reflection\Php;
 
+use phpDocumentor\Reflection\Exception;
 use phpDocumentor\Reflection\NodeVisitor\ElementNameResolver;
+use PhpParser\Error;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeTraverserInterface;
@@ -21,6 +23,8 @@ use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
 use Webmozart\Assert\Assert;
+
+use function sprintf;
 
 /**
  * Factory to create a array of nodes from a provided file.
@@ -59,12 +63,28 @@ class NodesFactory
      * Will convert the provided code to nodes.
      *
      * @param string $code code to process.
+     * @param string $filePath optional source file path for error context.
      *
      * @return Node[]
+     *
+     * @throws Exception when the provided code cannot be parsed.
      */
-    public function create(string $code): array
+    public function create(string $code, string $filePath = ''): array
     {
-        $nodes = $this->parser->parse($code);
+        try {
+            $nodes = $this->parser->parse($code);
+        } catch (Error $e) {
+            $line = $e->getStartLine();
+            $location = $filePath !== '' ? sprintf(' in %s', $filePath) : '';
+            $location .= $line > 0 ? sprintf(' on line %d', $line) : '';
+
+            throw new Exception(
+                sprintf('Syntax error%s: %s', $location, $e->getRawMessage()),
+                0,
+                $e,
+            );
+        }
+
         Assert::isArray($nodes);
 
         return $this->traverser->traverse($nodes);

--- a/tests/unit/phpDocumentor/Reflection/Php/Factory/FileTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/Factory/FileTest.php
@@ -79,7 +79,7 @@ final class FileTest extends TestCase
     public function testMiddlewareIsExecuted(): void
     {
         $file = new FileElement('aa', __FILE__);
-        $this->nodesFactoryMock->create(file_get_contents(__FILE__))->willReturn([]);
+        $this->nodesFactoryMock->create(file_get_contents(__FILE__), Argument::any())->willReturn([]);
         $middleware = $this->prophesize(Middleware::class);
         $middleware->execute(Argument::any(), Argument::any())->shouldBeCalled()->willReturn($file);
         $fixture = new File(
@@ -105,7 +105,7 @@ final class FileTest extends TestCase
     #[DataProvider('nodeProvider')]
     public function testFileGetsCommentFromFirstNode(Node $node, DocBlockDescriptor $docblock): void
     {
-        $this->nodesFactoryMock->create(file_get_contents(__FILE__))->willReturn([$node]);
+        $this->nodesFactoryMock->create(file_get_contents(__FILE__), Argument::any())->willReturn([$node]);
         $this->docBlockFactory->create('Text', Argument::any())->willReturn($docblock);
 
         $strategies = $this->prophesize(StrategyContainer::class);

--- a/tests/unit/phpDocumentor/Reflection/Php/NodesFactoryTest.php
+++ b/tests/unit/phpDocumentor/Reflection/Php/NodesFactoryTest.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Reflection\Php;
 
+use phpDocumentor\Reflection\Exception;
 use phpDocumentor\Reflection\NodeVisitor\ElementNameResolver;
+use PhpParser\Error;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeTraverserInterface;
 use PhpParser\NodeVisitor\NameResolver;
@@ -55,6 +57,44 @@ final class NodesFactoryTest extends TestCase
         $result = $factory->create('this is my code');
 
         $this->assertSame(['traversed code'], $result);
+    }
+
+    public function testThatParseErrorIncludesFileAndLine(): void
+    {
+        $factory = NodesFactory::createInstance();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Syntax error in /some/file.php on line 1:');
+
+        $factory->create('<?php class { }', '/some/file.php');
+    }
+
+    public function testThatParseErrorWithoutFilePathOnlyIncludesLine(): void
+    {
+        $factory = NodesFactory::createInstance();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Syntax error on line 1:');
+
+        $factory->create('<?php class { }');
+    }
+
+    public function testThatParseErrorWrapsOriginalException(): void
+    {
+        $parser = $this->prophesize(Parser::class);
+        $parser->parse('bad code')->willThrow(new Error('Unexpected token', ['startLine' => 42]));
+
+        $nodeTraverser = $this->prophesize(NodeTraverserInterface::class);
+
+        $factory = new NodesFactory($parser->reveal(), $nodeTraverser->reveal());
+
+        try {
+            $factory->create('bad code', '/path/to/source.php');
+            $this->fail('Expected Exception was not thrown');
+        } catch (Exception $e) {
+            $this->assertSame('Syntax error in /path/to/source.php on line 42: Unexpected token', $e->getMessage());
+            $this->assertInstanceOf(Error::class, $e->getPrevious());
+        }
     }
 
     private function givenTheExpectedDefaultNodesFactory(): NodesFactory


### PR DESCRIPTION
## Summary

When parsing a PHP file fails, the error now includes the source file path and line number instead of raw php-parser internals.

**Before:**
```
PhpParser\Error: Syntax error, unexpected T_STRING on line 42
```

**After:**
```
phpDocumentor\Reflection\Exception: Syntax error in /path/to/file.php on line 42: Syntax error, unexpected T_STRING
```

- `NodesFactory::create()` accepts an optional `$filePath` parameter
- Catches `PhpParser\Error` and re-throws as `phpDocumentor\Reflection\Exception` with file + line context
- `Factory\File` passes the source path automatically
- Original exception is preserved as `$previous` for debugging
- Fully backward-compatible (the new parameter is optional)

Suggested in https://github.com/phpDocumentor/phpDocumentor/pull/4088#issuecomment-4226251328 — moving the error enrichment into the reflection library so all consumers benefit.